### PR TITLE
 Pack terminal binaries in tar.gz archive

### DIFF
--- a/websocket-terminal/src/assembly/assembly.xml
+++ b/websocket-terminal/src/assembly/assembly.xml
@@ -18,6 +18,7 @@
     <baseDirectory>terminal</baseDirectory>
     <formats>
         <format>zip</format>
+        <format>tar.gz</format>
     </formats>
     <fileSets>
         <fileSet>


### PR DESCRIPTION
Tho goal is to reduce number of installing components in the container.