### PR TITLE
Use go flags to compile binaries in static mode

### DIFF
--- a/websocket-terminal/pom.xml
+++ b/websocket-terminal/pom.xml
@@ -169,10 +169,14 @@
                                         <workingDirectory>${project.build.directory}/${item}/go</workingDirectory>
                                         <arguments>
                                             <argument>build</argument>
+                                            <argument>-a</argument>
+                                            <argument>-installsuffix</argument>
+                                            <argument>cgo</argument>
                                             <argument>-o</argument>
                                             <argument>che-websocket-terminal</argument>
                                         </arguments>
                                         <environmentVariables>
+                                            <CGO_ENABLED>0</CGO_ENABLED>
                                             <GOOS>${terminal.target.os}</GOOS>
                                             <GOARCH>${terminal.target.architecture}</GOARCH>
                                             <GOARM>${terminal.target.arm.version}</GOARM>


### PR DESCRIPTION
So no need to have glibc installed for example (some "small in size" linux distributions don't have it by default like Alpine)