### PR TITLE
CHE-3768: change maven phase for replacing the path of the tooltip's images

### DIFF
--- a/che-orion-editor/pom.xml
+++ b/che-orion-editor/pom.xml
@@ -68,7 +68,7 @@
                 <executions>
                     <execution>
                         <id>replace</id>
-                        <phase>package</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>


### PR DESCRIPTION
### What does this PR do?
Change maven phase for replacing the path of the tooltip's images

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/3768

### Changelog
Fix problem wit showing tooltip's image in the editor
