### PR TITLE
Put logback-access logs archive in the same folder with catalina archive

### DIFF
--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback-access.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback-access.xml
@@ -29,7 +29,7 @@
             <pattern>common</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${che.logs.dir}/logs/archive/localhost-access-%d{yyyyMMdd}-%i.log.zip</fileNamePattern> 
+            <fileNamePattern>${che.logs.dir}/archive/localhost-access-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
             <maxHistory>${max.retention.days}</maxHistory>
             <maxFileSize>20MB</maxFileSize>
         </rollingPolicy>


### PR DESCRIPTION
### What does this PR do?
Put logback-access logs archive in the same folder with catalina archive

