### PR TITLE
Do not archive logs since it may leaves tmp files when program exits

### DIFF
--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback-access.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback-access.xml
@@ -29,7 +29,7 @@
             <pattern>common</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${che.logs.dir}/archive/localhost-access-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
+            <fileNamePattern>${che.logs.dir}/archive/localhost-access-%d{yyyyMMdd}-%i.log</fileNamePattern>
             <maxHistory>${max.retention.days}</maxHistory>
             <maxFileSize>20MB</maxFileSize>
         </rollingPolicy>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
@@ -31,7 +31,7 @@
             <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${che.logs.dir}/archive/catalina-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
+            <fileNamePattern>${che.logs.dir}/archive/catalina-%d{yyyyMMdd}-%i.log</fileNamePattern>
             <maxHistory>${max.retention.days}</maxHistory>
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
             <maxFileSize>20MB</maxFileSize>


### PR DESCRIPTION

### What does this PR do?
Do not archive logs since it may leaves tmp files when program exits
 See more https://jira.qos.ch/browse/LOGBACK-1162


### What issues does this PR fix or reference?
When file compression is enabled and triggered (gz or zip) and the program exits before Logback can complete the compression, the full-sized tmp file and an incomplete archive are created.
See more https://jira.qos.ch/browse/LOGBACK-1162
### Previous behavior
(Remove this section if not relevant)

### New behavior
(Explain the PR as it should appear in the release notes)

