### PR TITLE
Switching logback to prudent mode

### DIFF
--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
@@ -24,20 +24,17 @@
     </appender>
 
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${che.logs.dir}/logs/catalina.log</file>
         <append>true</append>
+        <prudent>true</prudent>
         <encoder>
             <charset>utf-8</charset>
             <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
         </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${che.logs.dir}/archive/catalina-%d{yyyyMMdd}-%i.log</fileNamePattern>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${che.logs.dir}/archive/%d{yyyy/MM/dd}/catalina.log</fileNamePattern>
             <maxHistory>${max.retention.days}</maxHistory>
-            <cleanHistoryOnStart>true</cleanHistoryOnStart>
-            <maxFileSize>20MB</maxFileSize>
         </rollingPolicy>
     </appender>
-
 
 
     <include optional="true" file="${che.local.conf.dir}/logback/logback-additional-appenders.xml"/>


### PR DESCRIPTION
### What does this PR do?
This PR switches logback configuration to `prudent` mode https://logback.qos.ch/manual/appenders.html#prudentWithRolling

### What issues does this PR fix or reference?
Looks like we have problems after switching to tomcat 8 - in some cases log files were written from different contexts, so overwriting occurs.

### New behavior
Logback now uses prudent mode - basically it locks files for writing.

### Tests written?
No

### Docs updated?
No