### PR TITLE
Add dependencies to allow using additional logstash-logback appenders in logback.xml

### DIFF
--- a/che-tomcat8-slf4j-logback/pom.xml
+++ b/che-tomcat8-slf4j-logback/pom.xml
@@ -36,8 +36,24 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>

--- a/che-tomcat8-slf4j-logback/src/assembly/assembly.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/assembly.xml
@@ -28,8 +28,14 @@
             <outputDirectory>lib</outputDirectory>
             <includes>
                 <include>ch.qos.logback:logback-access</include>
+                <include>ch.qos.logback:logback-classic</include>
                 <include>ch.qos.logback:logback-core</include>
+                <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                <include>com.fasterxml.jackson.core:jackson-core</include>
+                <include>com.fasterxml.jackson.core:jackson-databind</include>
+                <include>net.logstash.logback:logstash-logback-encoder</include>
                 <include>org.apache.tomcat:tomcat-catalina-jmx-remote</include>
+                <include>org.slf4j:slf4j-api</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
@@ -39,6 +39,8 @@
 
     <include optional="true" file="${che.local.conf.dir}/logback/logback-additional-appenders.xml"/>
 
+    <include optional="true" file="${catalina.home}/conf/logback-additional-appenders.xml"/>
+
     <logger name="org.apache.catalina.loader" level="OFF"/>
     <logger name="org.apache.catalina.session.PersistentManagerBase" level="OFF"/>
     <logger name="org.apache.jasper.servlet.TldScanner" level="OFF"/>


### PR DESCRIPTION
### What does this PR do?
- Add dependencies to allow using additional logstash-logback appenders in logback.xml
- Add a new `include` entry in logback.xml to allow adding more appenders from a custom assembly

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6537

### New behavior
Che users can now include logstash appenders in their custom assemblies for instance in ` `/home/user/eclipse-che-5.19.0-SNAPSHOT/tomcat/conf/logback-additional-appenders.xml`
```xml
<?xml version="1.0" encoding="UTF-8"?>
<included>
    <appender name="file-json" class="ch.qos.logback.core.rolling.RollingFileAppender">
        <file>${che.logs.dir}/logs/catalina.log.json</file>
        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
          <level>info</level>
        </filter>
        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
            <fileNamePattern>${che.logs.dir}/archive/%d{yyyy/MM/dd}/catalina.log.json</fileNamePattern>
            <maxHistory>${max.retention.days}</maxHistory>
        </rollingPolicy>
        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
    </appender>

    <root level="${che.logs.level:-INFO}">
        <appender-ref ref="file-json"/>
    </root>
</included>
```

### Tests written?
No

### Docs updated?
TODO after feedbacks on implementation
