### PR TITLE
Add profile to enable automatically dependency on tools.jar only for Java < 1.9 runtime

### DIFF
--- a/antlr-java5-grammar/pom.xml
+++ b/antlr-java5-grammar/pom.xml
@@ -30,13 +30,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>sun.jdt</groupId>
-            <artifactId>tools</artifactId>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-
     </dependencies>
     <build>
         <plugins>
@@ -53,4 +46,20 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>java8-tools</id>
+            <activation>
+                <jdk>(,1.9)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>sun.jdt</groupId>
+                    <artifactId>tools</artifactId>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### What does this PR do?
Add profile to enable tools.jar only for Java < 1.9

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5326

### Previous behavior
Fail to compile with Java9 runtime

### New behavior
Allow to compile with Java8 and Java9 runtime

### Tests written?
No

### Docs updated?
No