### PR TITLE
Update java source code formatter plugin version (che6)

### DIFF
--- a/antlr-java5-grammar/src/main/java/org/eclipse/che/plugin/jdb/server/expression/JavaLexer.java
+++ b/antlr-java5-grammar/src/main/java/org/eclipse/che/plugin/jdb/server/expression/JavaLexer.java
@@ -8,7 +8,8 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-// $ANTLR 3.3 Nov 30, 2010 12:50:56 org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g 2013-02-07 15:54:12
+// $ANTLR 3.3 Nov 30, 2010 12:50:56 org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g
+// 2013-02-07 15:54:12
 
 package org.eclipse.che.plugin.jdb.server.expression;
 
@@ -2030,9 +2031,11 @@ public class JavaLexer extends Lexer {
     try {
       int _type = HEX_LITERAL;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1083:13: ( '0' ( 'x' | 'X' ) ( HEX_DIGIT )+ (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1083:13: ( '0' ( 'x' | 'X' ) (
+      // HEX_DIGIT )+ (
       // INTEGER_TYPE_SUFFIX )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1083:15: '0' ( 'x' | 'X' ) ( HEX_DIGIT )+ (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1083:15: '0' ( 'x' | 'X' ) (
+      // HEX_DIGIT )+ (
       // INTEGER_TYPE_SUFFIX )?
       {
         match('0');
@@ -2074,7 +2077,8 @@ public class JavaLexer extends Lexer {
           cnt1++;
         } while (true);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1083:40: ( INTEGER_TYPE_SUFFIX )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1083:40: ( INTEGER_TYPE_SUFFIX
+        // )?
         int alt2 = 2;
         int LA2_0 = input.LA(1);
 
@@ -2083,7 +2087,8 @@ public class JavaLexer extends Lexer {
         }
         switch (alt2) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1083:40: INTEGER_TYPE_SUFFIX
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1083:40:
+            // INTEGER_TYPE_SUFFIX
             {
               mINTEGER_TYPE_SUFFIX();
             }
@@ -2103,12 +2108,15 @@ public class JavaLexer extends Lexer {
     try {
       int _type = DECIMAL_LITERAL;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:17: ( ( '0' | '1' .. '9' ( '0' .. '9' )* ) (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:17: ( ( '0' | '1' .. '9' (
+      // '0' .. '9' )* ) (
       // INTEGER_TYPE_SUFFIX )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:19: ( '0' | '1' .. '9' ( '0' .. '9' )* ) (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:19: ( '0' | '1' .. '9' ( '0'
+      // .. '9' )* ) (
       // INTEGER_TYPE_SUFFIX )?
       {
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:19: ( '0' | '1' .. '9' ( '0' .. '9' )* )
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:19: ( '0' | '1' .. '9' (
+        // '0' .. '9' )* )
         int alt4 = 2;
         int LA4_0 = input.LA(1);
 
@@ -2129,7 +2137,8 @@ public class JavaLexer extends Lexer {
             }
             break;
           case 2:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:26: '1' .. '9' ( '0' .. '9' )*
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:26: '1' .. '9' ( '0'
+            // .. '9' )*
             {
               matchRange('1', '9');
               // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:35: ( '0' .. '9' )*
@@ -2158,7 +2167,8 @@ public class JavaLexer extends Lexer {
             break;
         }
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:46: ( INTEGER_TYPE_SUFFIX )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:46: ( INTEGER_TYPE_SUFFIX
+        // )?
         int alt5 = 2;
         int LA5_0 = input.LA(1);
 
@@ -2167,7 +2177,8 @@ public class JavaLexer extends Lexer {
         }
         switch (alt5) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:46: INTEGER_TYPE_SUFFIX
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1085:46:
+            // INTEGER_TYPE_SUFFIX
             {
               mINTEGER_TYPE_SUFFIX();
             }
@@ -2187,8 +2198,10 @@ public class JavaLexer extends Lexer {
     try {
       int _type = OCTAL_LITERAL;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:15: ( '0' ( '0' .. '7' )+ ( INTEGER_TYPE_SUFFIX )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:17: '0' ( '0' .. '7' )+ ( INTEGER_TYPE_SUFFIX )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:15: ( '0' ( '0' .. '7' )+ (
+      // INTEGER_TYPE_SUFFIX )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:17: '0' ( '0' .. '7' )+ (
+      // INTEGER_TYPE_SUFFIX )?
       {
         match('0');
         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:21: ( '0' .. '7' )+
@@ -2218,7 +2231,8 @@ public class JavaLexer extends Lexer {
           cnt6++;
         } while (true);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:33: ( INTEGER_TYPE_SUFFIX )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:33: ( INTEGER_TYPE_SUFFIX
+        // )?
         int alt7 = 2;
         int LA7_0 = input.LA(1);
 
@@ -2227,7 +2241,8 @@ public class JavaLexer extends Lexer {
         }
         switch (alt7) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:33: INTEGER_TYPE_SUFFIX
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1087:33:
+            // INTEGER_TYPE_SUFFIX
             {
               mINTEGER_TYPE_SUFFIX();
             }
@@ -2245,8 +2260,10 @@ public class JavaLexer extends Lexer {
   // $ANTLR start "HEX_DIGIT"
   public final void mHEX_DIGIT() throws RecognitionException {
     try {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1090:11: ( ( '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1090:13: ( '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1090:11: ( ( '0' .. '9' | 'a' ..
+      // 'f' | 'A' .. 'F' ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1090:13: ( '0' .. '9' | 'a' ..
+      // 'f' | 'A' .. 'F' )
       {
         if ((input.LA(1) >= '0' && input.LA(1) <= '9')
             || (input.LA(1) >= 'A' && input.LA(1) <= 'F')
@@ -2291,8 +2308,10 @@ public class JavaLexer extends Lexer {
     try {
       int _type = FLOATING_POINT_LITERAL;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1096:5: ( ( '0' .. '9' )+ ( DOT ( '0' .. '9' )* ( EXPONENT
-      // )? ( FLOAT_TYPE_SUFFIX )? | EXPONENT ( FLOAT_TYPE_SUFFIX )? | FLOAT_TYPE_SUFFIX ) | DOT ( '0' .. '9' )+ ( EXPONENT )? (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1096:5: ( ( '0' .. '9' )+ ( DOT (
+      // '0' .. '9' )* ( EXPONENT
+      // )? ( FLOAT_TYPE_SUFFIX )? | EXPONENT ( FLOAT_TYPE_SUFFIX )? | FLOAT_TYPE_SUFFIX ) | DOT (
+      // '0' .. '9' )+ ( EXPONENT )? (
       // FLOAT_TYPE_SUFFIX )? )
       int alt17 = 2;
       int LA17_0 = input.LA(1);
@@ -2308,8 +2327,10 @@ public class JavaLexer extends Lexer {
       }
       switch (alt17) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1096:9: ( '0' .. '9' )+ ( DOT ( '0' .. '9' )* (
-          // EXPONENT )? ( FLOAT_TYPE_SUFFIX )? | EXPONENT ( FLOAT_TYPE_SUFFIX )? | FLOAT_TYPE_SUFFIX )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1096:9: ( '0' .. '9' )+ ( DOT
+          // ( '0' .. '9' )* (
+          // EXPONENT )? ( FLOAT_TYPE_SUFFIX )? | EXPONENT ( FLOAT_TYPE_SUFFIX )? |
+          // FLOAT_TYPE_SUFFIX )
           {
             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1096:9: ( '0' .. '9' )+
             int cnt8 = 0;
@@ -2338,7 +2359,8 @@ public class JavaLexer extends Lexer {
               cnt8++;
             } while (true);
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1097:9: ( DOT ( '0' .. '9' )* ( EXPONENT )? (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1097:9: ( DOT ( '0' .. '9'
+            // )* ( EXPONENT )? (
             // FLOAT_TYPE_SUFFIX )? | EXPONENT ( FLOAT_TYPE_SUFFIX )? | FLOAT_TYPE_SUFFIX )
             int alt13 = 3;
             switch (input.LA(1)) {
@@ -2369,11 +2391,13 @@ public class JavaLexer extends Lexer {
 
             switch (alt13) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:13: DOT ( '0' .. '9' )* ( EXPONENT )?
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:13: DOT ( '0' ..
+                // '9' )* ( EXPONENT )?
                 // ( FLOAT_TYPE_SUFFIX )?
                 {
                   mDOT();
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:17: ( '0' .. '9' )*
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:17: ( '0' .. '9'
+                  // )*
                   loop9:
                   do {
                     int alt9 = 2;
@@ -2385,7 +2409,8 @@ public class JavaLexer extends Lexer {
 
                     switch (alt9) {
                       case 1:
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:18: '0' .. '9'
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:18: '0' ..
+                        // '9'
                         {
                           matchRange('0', '9');
                         }
@@ -2396,7 +2421,8 @@ public class JavaLexer extends Lexer {
                     }
                   } while (true);
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:29: ( EXPONENT )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:29: ( EXPONENT
+                  // )?
                   int alt10 = 2;
                   int LA10_0 = input.LA(1);
 
@@ -2412,7 +2438,8 @@ public class JavaLexer extends Lexer {
                       break;
                   }
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:39: ( FLOAT_TYPE_SUFFIX )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:39: (
+                  // FLOAT_TYPE_SUFFIX )?
                   int alt11 = 2;
                   int LA11_0 = input.LA(1);
 
@@ -2421,7 +2448,8 @@ public class JavaLexer extends Lexer {
                   }
                   switch (alt11) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:39: FLOAT_TYPE_SUFFIX
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1098:39:
+                      // FLOAT_TYPE_SUFFIX
                       {
                         mFLOAT_TYPE_SUFFIX();
                       }
@@ -2430,10 +2458,12 @@ public class JavaLexer extends Lexer {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1099:13: EXPONENT ( FLOAT_TYPE_SUFFIX )?
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1099:13: EXPONENT (
+                // FLOAT_TYPE_SUFFIX )?
                 {
                   mEXPONENT();
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1099:22: ( FLOAT_TYPE_SUFFIX )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1099:22: (
+                  // FLOAT_TYPE_SUFFIX )?
                   int alt12 = 2;
                   int LA12_0 = input.LA(1);
 
@@ -2442,7 +2472,8 @@ public class JavaLexer extends Lexer {
                   }
                   switch (alt12) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1099:22: FLOAT_TYPE_SUFFIX
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1099:22:
+                      // FLOAT_TYPE_SUFFIX
                       {
                         mFLOAT_TYPE_SUFFIX();
                       }
@@ -2451,7 +2482,8 @@ public class JavaLexer extends Lexer {
                 }
                 break;
               case 3:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1100:13: FLOAT_TYPE_SUFFIX
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1100:13:
+                // FLOAT_TYPE_SUFFIX
                 {
                   mFLOAT_TYPE_SUFFIX();
                 }
@@ -2460,7 +2492,8 @@ public class JavaLexer extends Lexer {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1102:9: DOT ( '0' .. '9' )+ ( EXPONENT )? (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1102:9: DOT ( '0' .. '9' )+ (
+          // EXPONENT )? (
           // FLOAT_TYPE_SUFFIX )?
           {
             mDOT();
@@ -2507,7 +2540,8 @@ public class JavaLexer extends Lexer {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1102:35: ( FLOAT_TYPE_SUFFIX )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1102:35: (
+            // FLOAT_TYPE_SUFFIX )?
             int alt16 = 2;
             int LA16_0 = input.LA(1);
 
@@ -2516,7 +2550,8 @@ public class JavaLexer extends Lexer {
             }
             switch (alt16) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1102:35: FLOAT_TYPE_SUFFIX
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1102:35:
+                // FLOAT_TYPE_SUFFIX
                 {
                   mFLOAT_TYPE_SUFFIX();
                 }
@@ -2535,8 +2570,10 @@ public class JavaLexer extends Lexer {
   // $ANTLR start "EXPONENT"
   public final void mEXPONENT() throws RecognitionException {
     try {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1106:10: ( ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+ )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1106:12: ( 'e' | 'E' ) ( '+' | '-' )? ( '0' .. '9' )+
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1106:10: ( ( 'e' | 'E' ) ( '+' |
+      // '-' )? ( '0' .. '9' )+ )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1106:12: ( 'e' | 'E' ) ( '+' |
+      // '-' )? ( '0' .. '9' )+
       {
         if (input.LA(1) == 'E' || input.LA(1) == 'e') {
           input.consume();
@@ -2606,8 +2643,10 @@ public class JavaLexer extends Lexer {
   // $ANTLR start "FLOAT_TYPE_SUFFIX"
   public final void mFLOAT_TYPE_SUFFIX() throws RecognitionException {
     try {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1109:19: ( ( 'f' | 'F' | 'd' | 'D' ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1109:21: ( 'f' | 'F' | 'd' | 'D' )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1109:19: ( ( 'f' | 'F' | 'd' |
+      // 'D' ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1109:21: ( 'f' | 'F' | 'd' | 'D'
+      // )
       {
         if (input.LA(1) == 'D' || input.LA(1) == 'F' || input.LA(1) == 'd' || input.LA(1) == 'f') {
           input.consume();
@@ -2629,13 +2668,16 @@ public class JavaLexer extends Lexer {
     try {
       int _type = CHARACTER_LITERAL;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1112:5: ( '\\'' ( ESCAPE_SEQUENCE | ~ ( '\\'' | '\\\\' ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1112:5: ( '\\'' ( ESCAPE_SEQUENCE
+      // | ~ ( '\\'' | '\\\\' ) )
       // '\\'' )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1112:9: '\\'' ( ESCAPE_SEQUENCE | ~ ( '\\'' | '\\\\' ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1112:9: '\\'' ( ESCAPE_SEQUENCE |
+      // ~ ( '\\'' | '\\\\' ) )
       // '\\''
       {
         match('\'');
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1112:14: ( ESCAPE_SEQUENCE | ~ ( '\\'' | '\\\\' ) )
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1112:14: ( ESCAPE_SEQUENCE | ~
+        // ( '\\'' | '\\\\' ) )
         int alt20 = 2;
         int LA20_0 = input.LA(1);
 
@@ -2658,7 +2700,8 @@ public class JavaLexer extends Lexer {
             }
             break;
           case 2:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1112:34: ~ ( '\\'' | '\\\\' )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1112:34: ~ ( '\\'' | '\\\\'
+            // )
             {
               if ((input.LA(1) >= '\u0000' && input.LA(1) <= '&')
                   || (input.LA(1) >= '(' && input.LA(1) <= '[')
@@ -2689,12 +2732,15 @@ public class JavaLexer extends Lexer {
     try {
       int _type = STRING_LITERAL;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1116:5: ( '\"' ( ESCAPE_SEQUENCE | ~ ( '\\\\' | '\"' ) )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1116:5: ( '\"' ( ESCAPE_SEQUENCE
+      // | ~ ( '\\\\' | '\"' ) )*
       // '\"' )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1116:8: '\"' ( ESCAPE_SEQUENCE | ~ ( '\\\\' | '\"' ) )* '\"'
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1116:8: '\"' ( ESCAPE_SEQUENCE |
+      // ~ ( '\\\\' | '\"' ) )* '\"'
       {
         match('\"');
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1116:12: ( ESCAPE_SEQUENCE | ~ ( '\\\\' | '\"' ) )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1116:12: ( ESCAPE_SEQUENCE | ~
+        // ( '\\\\' | '\"' ) )*
         loop21:
         do {
           int alt21 = 3;
@@ -2716,7 +2762,8 @@ public class JavaLexer extends Lexer {
               }
               break;
             case 2:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1116:32: ~ ( '\\\\' | '\"' )
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1116:32: ~ ( '\\\\' |
+              // '\"' )
               {
                 if ((input.LA(1) >= '\u0000' && input.LA(1) <= '!')
                     || (input.LA(1) >= '#' && input.LA(1) <= '[')
@@ -2749,7 +2796,8 @@ public class JavaLexer extends Lexer {
   // $ANTLR start "ESCAPE_SEQUENCE"
   public final void mESCAPE_SEQUENCE() throws RecognitionException {
     try {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1121:5: ( '\\\\' ( 'b' | 't' | 'n' | 'f' | 'r' | '\\\"' |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1121:5: ( '\\\\' ( 'b' | 't' |
+      // 'n' | 'f' | 'r' | '\\\"' |
       // '\\'' | '\\\\' ) | UNICODE_ESCAPE | OCTAL_ESCAPE )
       int alt22 = 3;
       int LA22_0 = input.LA(1);
@@ -2798,7 +2846,8 @@ public class JavaLexer extends Lexer {
       }
       switch (alt22) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1121:9: '\\\\' ( 'b' | 't' | 'n' | 'f' | 'r' |
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1121:9: '\\\\' ( 'b' | 't' |
+          // 'n' | 'f' | 'r' |
           // '\\\"' | '\\'' | '\\\\' )
           {
             match('\\');
@@ -2840,7 +2889,8 @@ public class JavaLexer extends Lexer {
   // $ANTLR start "OCTAL_ESCAPE"
   public final void mOCTAL_ESCAPE() throws RecognitionException {
     try {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1128:5: ( '\\\\' ( '0' .. '3' ) ( '0' .. '7' ) ( '0' ..
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1128:5: ( '\\\\' ( '0' .. '3' ) (
+      // '0' .. '7' ) ( '0' ..
       // '7' ) | '\\\\' ( '0' .. '7' ) ( '0' .. '7' ) | '\\\\' ( '0' .. '7' ) )
       int alt23 = 3;
       int LA23_0 = input.LA(1);
@@ -2882,7 +2932,8 @@ public class JavaLexer extends Lexer {
       }
       switch (alt23) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1128:9: '\\\\' ( '0' .. '3' ) ( '0' .. '7' ) ( '0'
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1128:9: '\\\\' ( '0' .. '3' )
+          // ( '0' .. '7' ) ( '0'
           // .. '7' )
           {
             match('\\');
@@ -2906,7 +2957,8 @@ public class JavaLexer extends Lexer {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1129:9: '\\\\' ( '0' .. '7' ) ( '0' .. '7' )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1129:9: '\\\\' ( '0' .. '7' )
+          // ( '0' .. '7' )
           {
             match('\\');
             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1129:14: ( '0' .. '7' )
@@ -2942,9 +2994,11 @@ public class JavaLexer extends Lexer {
   // $ANTLR start "UNICODE_ESCAPE"
   public final void mUNICODE_ESCAPE() throws RecognitionException {
     try {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1135:5: ( '\\\\' 'u' HEX_DIGIT HEX_DIGIT HEX_DIGIT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1135:5: ( '\\\\' 'u' HEX_DIGIT
+      // HEX_DIGIT HEX_DIGIT
       // HEX_DIGIT )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1135:9: '\\\\' 'u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1135:9: '\\\\' 'u' HEX_DIGIT
+      // HEX_DIGIT HEX_DIGIT HEX_DIGIT
       {
         match('\\');
         match('u');
@@ -2964,8 +3018,10 @@ public class JavaLexer extends Lexer {
     try {
       int _type = IDENT;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1139:5: ( JAVA_ID_START ( JAVA_ID_PART )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1139:9: JAVA_ID_START ( JAVA_ID_PART )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1139:5: ( JAVA_ID_START (
+      // JAVA_ID_PART )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1139:9: JAVA_ID_START (
+      // JAVA_ID_PART )*
       {
         mJAVA_ID_START();
         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1139:23: ( JAVA_ID_PART )*
@@ -3014,9 +3070,12 @@ public class JavaLexer extends Lexer {
   // $ANTLR start "JAVA_ID_START"
   public final void mJAVA_ID_START() throws RecognitionException {
     try {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1144:5: ( '\\u0024' | '\\u0041' .. '\\u005a' | '\\u005f' |
-      // '\\u0061' .. '\\u007a' | '\\u00c0' .. '\\u00d6' | '\\u00d8' .. '\\u00f6' | '\\u00f8' .. '\\u00ff' | '\\u0100' .. '\\u1fff'
-      // | '\\u3040' .. '\\u318f' | '\\u3300' .. '\\u337f' | '\\u3400' .. '\\u3d2d' | '\\u4e00' .. '\\u9fff' | '\\uf900' ..
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1144:5: ( '\\u0024' | '\\u0041'
+      // .. '\\u005a' | '\\u005f' |
+      // '\\u0061' .. '\\u007a' | '\\u00c0' .. '\\u00d6' | '\\u00d8' .. '\\u00f6' | '\\u00f8' ..
+      // '\\u00ff' | '\\u0100' .. '\\u1fff'
+      // | '\\u3040' .. '\\u318f' | '\\u3300' .. '\\u337f' | '\\u3400' .. '\\u3d2d' | '\\u4e00' ..
+      // '\\u9fff' | '\\uf900' ..
       // '\\ufaff' )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:
       {
@@ -3049,7 +3108,8 @@ public class JavaLexer extends Lexer {
   // $ANTLR start "JAVA_ID_PART"
   public final void mJAVA_ID_PART() throws RecognitionException {
     try {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1161:5: ( JAVA_ID_START | '\\u0030' .. '\\u0039' )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1161:5: ( JAVA_ID_START |
+      // '\\u0030' .. '\\u0039' )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:
       {
         if (input.LA(1) == '$'
@@ -3084,8 +3144,10 @@ public class JavaLexer extends Lexer {
     try {
       int _type = WS;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1165:5: ( ( ' ' | '\\r' | '\\t' | '\\u000C' | '\\n' ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1165:8: ( ' ' | '\\r' | '\\t' | '\\u000C' | '\\n' )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1165:5: ( ( ' ' | '\\r' | '\\t' |
+      // '\\u000C' | '\\n' ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1165:8: ( ' ' | '\\r' | '\\t' |
+      // '\\u000C' | '\\n' )
       {
         if ((input.LA(1) >= '\t' && input.LA(1) <= '\n')
             || (input.LA(1) >= '\f' && input.LA(1) <= '\r')
@@ -3117,12 +3179,15 @@ public class JavaLexer extends Lexer {
     try {
       int _type = COMMENT;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1176:5: ( '/*' ( options {greedy=false; } : . )* '*/' )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1176:9: '/*' ( options {greedy=false; } : . )* '*/'
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1176:5: ( '/*' ( options
+      // {greedy=false; } : . )* '*/' )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1176:9: '/*' ( options
+      // {greedy=false; } : . )* '*/'
       {
         match("/*");
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1176:14: ( options {greedy=false; } : . )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1176:14: ( options
+        // {greedy=false; } : . )*
         loop25:
         do {
           int alt25 = 2;
@@ -3177,12 +3242,15 @@ public class JavaLexer extends Lexer {
     try {
       int _type = LINE_COMMENT;
       int _channel = DEFAULT_TOKEN_CHANNEL;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1187:5: ( '//' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n' )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1187:7: '//' (~ ( '\\n' | '\\r' ) )* ( '\\r' )? '\\n'
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1187:5: ( '//' (~ ( '\\n' | '\\r'
+      // ) )* ( '\\r' )? '\\n' )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1187:7: '//' (~ ( '\\n' | '\\r' )
+      // )* ( '\\r' )? '\\n'
       {
         match("//");
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1187:12: (~ ( '\\n' | '\\r' ) )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1187:12: (~ ( '\\n' | '\\r' )
+        // )*
         loop26:
         do {
           int alt26 = 2;
@@ -3196,7 +3264,8 @@ public class JavaLexer extends Lexer {
 
           switch (alt26) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1187:12: ~ ( '\\n' | '\\r' )
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1187:12: ~ ( '\\n' |
+              // '\\r' )
               {
                 if ((input.LA(1) >= '\u0000' && input.LA(1) <= '\t')
                     || (input.LA(1) >= '\u000B' && input.LA(1) <= '\f')
@@ -3249,16 +3318,26 @@ public class JavaLexer extends Lexer {
   // $ANTLR end "LINE_COMMENT"
 
   public void mTokens() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1:8: ( AND | AND_ASSIGN | ASSIGN | AT | BIT_SHIFT_RIGHT |
-    // BIT_SHIFT_RIGHT_ASSIGN | COLON | COMMA | DEC | DIV | DIV_ASSIGN | DOT | DOTSTAR | ELLIPSIS | EQUAL | GREATER_OR_EQUAL |
-    // GREATER_THAN | INC | LBRACK | LCURLY | LESS_OR_EQUAL | LESS_THAN | LOGICAL_AND | LOGICAL_NOT | LOGICAL_OR | LPAREN | MINUS |
-    // MINUS_ASSIGN | MOD | MOD_ASSIGN | NOT | NOT_EQUAL | OR | OR_ASSIGN | PLUS | PLUS_ASSIGN | QUESTION | RBRACK | RCURLY | RPAREN
-    // | SEMI | SHIFT_LEFT | SHIFT_LEFT_ASSIGN | SHIFT_RIGHT | SHIFT_RIGHT_ASSIGN | STAR | STAR_ASSIGN | XOR | XOR_ASSIGN | ABSTRACT
-    // | ASSERT | BOOLEAN | BREAK | BYTE | CASE | CATCH | CHAR | CLASS | CONTINUE | DEFAULT | DO | DOUBLE | ELSE | ENUM | EXTENDS |
-    // FALSE | FINAL | FINALLY | FLOAT | FOR | IF | IMPLEMENTS | INSTANCEOF | INTERFACE | IMPORT | INT | LONG | NATIVE | NEW | NULL |
-    // PACKAGE | PRIVATE | PROTECTED | PUBLIC | RETURN | SHORT | STATIC | STRICTFP | SUPER | SWITCH | SYNCHRONIZED | THIS | THROW |
-    // THROWS | TRANSIENT | TRUE | TRY | VOID | VOLATILE | WHILE | HEX_LITERAL | DECIMAL_LITERAL | OCTAL_LITERAL |
-    // FLOATING_POINT_LITERAL | CHARACTER_LITERAL | STRING_LITERAL | IDENT | WS | COMMENT | LINE_COMMENT )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1:8: ( AND | AND_ASSIGN | ASSIGN |
+    // AT | BIT_SHIFT_RIGHT |
+    // BIT_SHIFT_RIGHT_ASSIGN | COLON | COMMA | DEC | DIV | DIV_ASSIGN | DOT | DOTSTAR | ELLIPSIS |
+    // EQUAL | GREATER_OR_EQUAL |
+    // GREATER_THAN | INC | LBRACK | LCURLY | LESS_OR_EQUAL | LESS_THAN | LOGICAL_AND | LOGICAL_NOT
+    // | LOGICAL_OR | LPAREN | MINUS |
+    // MINUS_ASSIGN | MOD | MOD_ASSIGN | NOT | NOT_EQUAL | OR | OR_ASSIGN | PLUS | PLUS_ASSIGN |
+    // QUESTION | RBRACK | RCURLY | RPAREN
+    // | SEMI | SHIFT_LEFT | SHIFT_LEFT_ASSIGN | SHIFT_RIGHT | SHIFT_RIGHT_ASSIGN | STAR |
+    // STAR_ASSIGN | XOR | XOR_ASSIGN | ABSTRACT
+    // | ASSERT | BOOLEAN | BREAK | BYTE | CASE | CATCH | CHAR | CLASS | CONTINUE | DEFAULT | DO |
+    // DOUBLE | ELSE | ENUM | EXTENDS |
+    // FALSE | FINAL | FINALLY | FLOAT | FOR | IF | IMPLEMENTS | INSTANCEOF | INTERFACE | IMPORT |
+    // INT | LONG | NATIVE | NEW | NULL |
+    // PACKAGE | PRIVATE | PROTECTED | PUBLIC | RETURN | SHORT | STATIC | STRICTFP | SUPER | SWITCH
+    // | SYNCHRONIZED | THIS | THROW |
+    // THROWS | TRANSIENT | TRUE | TRY | VOID | VOLATILE | WHILE | HEX_LITERAL | DECIMAL_LITERAL |
+    // OCTAL_LITERAL |
+    // FLOATING_POINT_LITERAL | CHARACTER_LITERAL | STRING_LITERAL | IDENT | WS | COMMENT |
+    // LINE_COMMENT )
     int alt28 = 110;
     alt28 = dfa28.predict(input);
     switch (alt28) {

--- a/antlr-java5-grammar/src/main/java/org/eclipse/che/plugin/jdb/server/expression/JavaParser.java
+++ b/antlr-java5-grammar/src/main/java/org/eclipse/che/plugin/jdb/server/expression/JavaParser.java
@@ -8,7 +8,8 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-// $ANTLR 3.3 Nov 30, 2010 12:50:56 org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g 2013-02-07 15:54:12
+// $ANTLR 3.3 Nov 30, 2010 12:50:56 org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g
+// 2013-02-07 15:54:12
 
 package org.eclipse.che.plugin.jdb.server.expression;
 
@@ -536,7 +537,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "javaSource"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:324:1: javaSource : compilationUnit -> ^( JAVA_SOURCE
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:324:1: javaSource : compilationUnit
+  // -> ^( JAVA_SOURCE
   // compilationUnit ) ;
   public final JavaParser.javaSource_return javaSource() throws RecognitionException {
     JavaParser.javaSource_return retval = new JavaParser.javaSource_return();
@@ -552,7 +554,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 1)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:325:5: ( compilationUnit -> ^( JAVA_SOURCE compilationUnit
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:325:5: ( compilationUnit -> ^(
+      // JAVA_SOURCE compilationUnit
       // ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:325:9: compilationUnit
       {
@@ -579,7 +582,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 326:9: -> ^( JAVA_SOURCE compilationUnit )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:326:13: ^( JAVA_SOURCE compilationUnit )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:326:13: ^( JAVA_SOURCE
+            // compilationUnit )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -627,7 +631,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "compilationUnit"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:329:1: compilationUnit : annotationList ( packageDeclaration )? (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:329:1: compilationUnit :
+  // annotationList ( packageDeclaration )? (
   // importDeclaration )* ( typeDecls )* ;
   public final JavaParser.compilationUnit_return compilationUnit() throws RecognitionException {
     JavaParser.compilationUnit_return retval = new JavaParser.compilationUnit_return();
@@ -647,9 +652,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 2)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:330:5: ( annotationList ( packageDeclaration )? (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:330:5: ( annotationList (
+      // packageDeclaration )? (
       // importDeclaration )* ( typeDecls )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:330:9: annotationList ( packageDeclaration )? (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:330:9: annotationList (
+      // packageDeclaration )? (
       // importDeclaration )* ( typeDecls )*
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -786,7 +793,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "typeDecls"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:336:1: typeDecls : ( typeDeclaration | SEMI );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:336:1: typeDecls : ( typeDeclaration
+  // | SEMI );
   public final JavaParser.typeDecls_return typeDecls() throws RecognitionException {
     JavaParser.typeDecls_return retval = new JavaParser.typeDecls_return();
     retval.start = input.LT(1);
@@ -890,7 +898,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "packageDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:341:1: packageDeclaration : PACKAGE qualifiedIdentifier SEMI ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:341:1: packageDeclaration : PACKAGE
+  // qualifiedIdentifier SEMI ;
   public final JavaParser.packageDeclaration_return packageDeclaration()
       throws RecognitionException {
     JavaParser.packageDeclaration_return retval = new JavaParser.packageDeclaration_return();
@@ -909,8 +918,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 4)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:342:5: ( PACKAGE qualifiedIdentifier SEMI )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:342:9: PACKAGE qualifiedIdentifier SEMI
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:342:5: ( PACKAGE
+      // qualifiedIdentifier SEMI )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:342:9: PACKAGE
+      // qualifiedIdentifier SEMI
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -960,7 +971,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "importDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:345:1: importDeclaration : IMPORT ( STATIC )? qualifiedIdentifier
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:345:1: importDeclaration : IMPORT (
+  // STATIC )? qualifiedIdentifier
   // ( DOTSTAR )? SEMI ;
   public final JavaParser.importDeclaration_return importDeclaration() throws RecognitionException {
     JavaParser.importDeclaration_return retval = new JavaParser.importDeclaration_return();
@@ -983,9 +995,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 5)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:346:5: ( IMPORT ( STATIC )? qualifiedIdentifier ( DOTSTAR
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:346:5: ( IMPORT ( STATIC )?
+      // qualifiedIdentifier ( DOTSTAR
       // )? SEMI )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:346:9: IMPORT ( STATIC )? qualifiedIdentifier ( DOTSTAR )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:346:9: IMPORT ( STATIC )?
+      // qualifiedIdentifier ( DOTSTAR )?
       // SEMI
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -1078,8 +1092,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "typeDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:349:1: typeDeclaration : modifierList (
-  // classTypeDeclaration[$modifierList.tree] | interfaceTypeDeclaration[$modifierList.tree] | enumTypeDeclaration[$modifierList.tree]
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:349:1: typeDeclaration : modifierList
+  // (
+  // classTypeDeclaration[$modifierList.tree] | interfaceTypeDeclaration[$modifierList.tree] |
+  // enumTypeDeclaration[$modifierList.tree]
   // | annotationTypeDeclaration[$modifierList.tree] ) ;
   public final JavaParser.typeDeclaration_return typeDeclaration() throws RecognitionException {
     JavaParser.typeDeclaration_return retval = new JavaParser.typeDeclaration_return();
@@ -1101,11 +1117,15 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 6)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:350:5: ( modifierList ( classTypeDeclaration[$modifierList
-      // .tree] | interfaceTypeDeclaration[$modifierList.tree] | enumTypeDeclaration[$modifierList.tree] |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:350:5: ( modifierList (
+      // classTypeDeclaration[$modifierList
+      // .tree] | interfaceTypeDeclaration[$modifierList.tree] |
+      // enumTypeDeclaration[$modifierList.tree] |
       // annotationTypeDeclaration[$modifierList.tree] ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:350:9: modifierList ( classTypeDeclaration[$modifierList
-      // .tree] | interfaceTypeDeclaration[$modifierList.tree] | enumTypeDeclaration[$modifierList.tree] |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:350:9: modifierList (
+      // classTypeDeclaration[$modifierList
+      // .tree] | interfaceTypeDeclaration[$modifierList.tree] |
+      // enumTypeDeclaration[$modifierList.tree] |
       // annotationTypeDeclaration[$modifierList.tree] )
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -1115,7 +1135,8 @@ public class JavaParser extends Parser {
 
         state._fsp--;
         if (state.failed) return retval;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:351:9: ( classTypeDeclaration[$modifierList.tree] |
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:351:9: (
+        // classTypeDeclaration[$modifierList.tree] |
         // interfaceTypeDeclaration[$modifierList.tree] | enumTypeDeclaration[$modifierList.tree] |
         // annotationTypeDeclaration[$modifierList.tree] )
         int alt7 = 4;
@@ -1152,7 +1173,8 @@ public class JavaParser extends Parser {
 
         switch (alt7) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:351:13: classTypeDeclaration[$modifierList.tree]
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:351:13:
+            // classTypeDeclaration[$modifierList.tree]
             {
               pushFollow(FOLLOW_classTypeDeclaration_in_typeDeclaration4708);
               classTypeDeclaration17 =
@@ -1166,7 +1188,8 @@ public class JavaParser extends Parser {
             }
             break;
           case 2:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:352:13: interfaceTypeDeclaration[$modifierList
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:352:13:
+            // interfaceTypeDeclaration[$modifierList
             // .tree]
             {
               pushFollow(FOLLOW_interfaceTypeDeclaration_in_typeDeclaration4723);
@@ -1181,7 +1204,8 @@ public class JavaParser extends Parser {
             }
             break;
           case 3:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:353:13: enumTypeDeclaration[$modifierList.tree]
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:353:13:
+            // enumTypeDeclaration[$modifierList.tree]
             {
               pushFollow(FOLLOW_enumTypeDeclaration_in_typeDeclaration4738);
               enumTypeDeclaration19 =
@@ -1242,8 +1266,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "classTypeDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:358:1: classTypeDeclaration[CommonTree modifiers] : CLASS IDENT (
-  // genericTypeParameterList )? ( classExtendsClause )? ( implementsClause )? classBody -> ^( CLASS IDENT ( genericTypeParameterList )
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:358:1:
+  // classTypeDeclaration[CommonTree modifiers] : CLASS IDENT (
+  // genericTypeParameterList )? ( classExtendsClause )? ( implementsClause )? classBody -> ^( CLASS
+  // IDENT ( genericTypeParameterList )
   // ? ( classExtendsClause )? ( implementsClause )? classBody ) ;
   public final JavaParser.classTypeDeclaration_return classTypeDeclaration(CommonTree modifiers)
       throws RecognitionException {
@@ -1278,10 +1304,13 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 7)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:359:5: ( CLASS IDENT ( genericTypeParameterList )? (
-      // classExtendsClause )? ( implementsClause )? classBody -> ^( CLASS IDENT ( genericTypeParameterList )? ( classExtendsClause
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:359:5: ( CLASS IDENT (
+      // genericTypeParameterList )? (
+      // classExtendsClause )? ( implementsClause )? classBody -> ^( CLASS IDENT (
+      // genericTypeParameterList )? ( classExtendsClause
       // )? ( implementsClause )? classBody ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:359:9: CLASS IDENT ( genericTypeParameterList )? (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:359:9: CLASS IDENT (
+      // genericTypeParameterList )? (
       // classExtendsClause )? ( implementsClause )? classBody
       {
         CLASS21 = (Token) match(input, CLASS, FOLLOW_CLASS_in_classTypeDeclaration4788);
@@ -1292,7 +1321,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_IDENT.add(IDENT22);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:359:21: ( genericTypeParameterList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:359:21: (
+        // genericTypeParameterList )?
         int alt8 = 2;
         int LA8_0 = input.LA(1);
 
@@ -1301,7 +1331,8 @@ public class JavaParser extends Parser {
         }
         switch (alt8) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeParameterList
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+            // genericTypeParameterList
             {
               pushFollow(FOLLOW_genericTypeParameterList_in_classTypeDeclaration4792);
               genericTypeParameterList23 = genericTypeParameterList();
@@ -1366,7 +1397,8 @@ public class JavaParser extends Parser {
         if (state.backtracking == 0) stream_classBody.add(classBody26.getTree());
 
         // AST REWRITE
-        // elements: IDENT, classExtendsClause, genericTypeParameterList, CLASS, implementsClause, classBody
+        // elements: IDENT, classExtendsClause, genericTypeParameterList, CLASS, implementsClause,
+        // classBody
         // token labels:
         // rule labels: retval
         // token list labels:
@@ -1379,7 +1411,8 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 360:9: -> ^( CLASS IDENT ( genericTypeParameterList )? ( classExtendsClause )? ( implementsClause )? classBody )
+          // 360:9: -> ^( CLASS IDENT ( genericTypeParameterList )? ( classExtendsClause )? (
+          // implementsClause )? classBody )
           {
             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:360:13: ^( CLASS IDENT (
             // genericTypeParameterList )? ( classExtendsClause )? ( implementsClause )? classBody )
@@ -1389,17 +1422,20 @@ public class JavaParser extends Parser {
 
               adaptor.addChild(root_1, modifiers);
               adaptor.addChild(root_1, stream_IDENT.nextNode());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:360:40: ( genericTypeParameterList )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:360:40: (
+              // genericTypeParameterList )?
               if (stream_genericTypeParameterList.hasNext()) {
                 adaptor.addChild(root_1, stream_genericTypeParameterList.nextTree());
               }
               stream_genericTypeParameterList.reset();
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:360:66: ( classExtendsClause )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:360:66: (
+              // classExtendsClause )?
               if (stream_classExtendsClause.hasNext()) {
                 adaptor.addChild(root_1, stream_classExtendsClause.nextTree());
               }
               stream_classExtendsClause.reset();
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:360:86: ( implementsClause )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:360:86: (
+              // implementsClause )?
               if (stream_implementsClause.hasNext()) {
                 adaptor.addChild(root_1, stream_implementsClause.nextTree());
               }
@@ -1444,7 +1480,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "classExtendsClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:363:1: classExtendsClause : EXTENDS type -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:363:1: classExtendsClause : EXTENDS
+  // type -> ^(
   // EXTENDS_CLAUSE[$EXTENDS, \"EXTENDS_CLAUSE\"] type ) ;
   public final JavaParser.classExtendsClause_return classExtendsClause()
       throws RecognitionException {
@@ -1463,7 +1500,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 8)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:364:5: ( EXTENDS type -> ^( EXTENDS_CLAUSE[$EXTENDS,
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:364:5: ( EXTENDS type -> ^(
+      // EXTENDS_CLAUSE[$EXTENDS,
       // \"EXTENDS_CLAUSE\"] type ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:364:9: EXTENDS type
       {
@@ -1494,7 +1532,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 365:9: -> ^( EXTENDS_CLAUSE[$EXTENDS, \"EXTENDS_CLAUSE\"] type )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:365:13: ^( EXTENDS_CLAUSE[$EXTENDS,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:365:13: ^(
+            // EXTENDS_CLAUSE[$EXTENDS,
             // \"EXTENDS_CLAUSE\"] type )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -1544,7 +1583,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "interfaceExtendsClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:368:1: interfaceExtendsClause : EXTENDS typeList -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:368:1: interfaceExtendsClause :
+  // EXTENDS typeList -> ^(
   // EXTENDS_CLAUSE[$EXTENDS, \"EXTENDS_CLAUSE\"] typeList ) ;
   public final JavaParser.interfaceExtendsClause_return interfaceExtendsClause()
       throws RecognitionException {
@@ -1565,7 +1605,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 9)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:369:5: ( EXTENDS typeList -> ^( EXTENDS_CLAUSE[$EXTENDS,
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:369:5: ( EXTENDS typeList -> ^(
+      // EXTENDS_CLAUSE[$EXTENDS,
       // \"EXTENDS_CLAUSE\"] typeList ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:369:9: EXTENDS typeList
       {
@@ -1596,7 +1637,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 370:9: -> ^( EXTENDS_CLAUSE[$EXTENDS, \"EXTENDS_CLAUSE\"] typeList )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:370:13: ^( EXTENDS_CLAUSE[$EXTENDS,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:370:13: ^(
+            // EXTENDS_CLAUSE[$EXTENDS,
             // \"EXTENDS_CLAUSE\"] typeList )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -1646,7 +1688,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "implementsClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:373:1: implementsClause : IMPLEMENTS typeList -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:373:1: implementsClause : IMPLEMENTS
+  // typeList -> ^(
   // IMPLEMENTS_CLAUSE[$IMPLEMENTS, \"IMPLEMENTS_CLAUSE\"] typeList ) ;
   public final JavaParser.implementsClause_return implementsClause() throws RecognitionException {
     JavaParser.implementsClause_return retval = new JavaParser.implementsClause_return();
@@ -1666,7 +1709,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 10)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:374:5: ( IMPLEMENTS typeList -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:374:5: ( IMPLEMENTS typeList ->
+      // ^(
       // IMPLEMENTS_CLAUSE[$IMPLEMENTS, \"IMPLEMENTS_CLAUSE\"] typeList ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:374:9: IMPLEMENTS typeList
       {
@@ -1697,7 +1741,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 375:9: -> ^( IMPLEMENTS_CLAUSE[$IMPLEMENTS, \"IMPLEMENTS_CLAUSE\"] typeList )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:375:13: ^( IMPLEMENTS_CLAUSE[$IMPLEMENTS,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:375:13: ^(
+            // IMPLEMENTS_CLAUSE[$IMPLEMENTS,
             // \"IMPLEMENTS_CLAUSE\"] typeList )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -1748,7 +1793,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "genericTypeParameterList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:378:1: genericTypeParameterList : LESS_THAN genericTypeParameter (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:378:1: genericTypeParameterList :
+  // LESS_THAN genericTypeParameter (
   // COMMA genericTypeParameter )* genericTypeListClosing -> ^( GENERIC_TYPE_PARAM_LIST[$LESS_THAN,
   // \"GENERIC_TYPE_PARAM_LIST\"] ( genericTypeParameter )+ ) ;
   public final JavaParser.genericTypeParameterList_return genericTypeParameterList()
@@ -1780,10 +1826,12 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 11)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:379:5: ( LESS_THAN genericTypeParameter ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:379:5: ( LESS_THAN
+      // genericTypeParameter ( COMMA
       // genericTypeParameter )* genericTypeListClosing -> ^( GENERIC_TYPE_PARAM_LIST[$LESS_THAN,
       // \"GENERIC_TYPE_PARAM_LIST\"] ( genericTypeParameter )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:379:9: LESS_THAN genericTypeParameter ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:379:9: LESS_THAN
+      // genericTypeParameter ( COMMA
       // genericTypeParameter )* genericTypeListClosing
       {
         LESS_THAN33 =
@@ -1798,7 +1846,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           stream_genericTypeParameter.add(genericTypeParameter34.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:379:40: ( COMMA genericTypeParameter )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:379:40: ( COMMA
+        // genericTypeParameter )*
         loop11:
         do {
           int alt11 = 2;
@@ -1810,7 +1859,8 @@ public class JavaParser extends Parser {
 
           switch (alt11) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:379:41: COMMA genericTypeParameter
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:379:41: COMMA
+              // genericTypeParameter
               {
                 COMMA35 = (Token) match(input, COMMA, FOLLOW_COMMA_in_genericTypeParameterList4998);
                 if (state.failed) return retval;
@@ -1853,9 +1903,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 380:9: -> ^( GENERIC_TYPE_PARAM_LIST[$LESS_THAN, \"GENERIC_TYPE_PARAM_LIST\"] ( genericTypeParameter )+ )
+          // 380:9: -> ^( GENERIC_TYPE_PARAM_LIST[$LESS_THAN, \"GENERIC_TYPE_PARAM_LIST\"] (
+          // genericTypeParameter )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:380:13: ^( GENERIC_TYPE_PARAM_LIST[$LESS_THAN,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:380:13: ^(
+            // GENERIC_TYPE_PARAM_LIST[$LESS_THAN,
             // \"GENERIC_TYPE_PARAM_LIST\"] ( genericTypeParameter )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -1913,7 +1965,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "genericTypeListClosing"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:383:1: genericTypeListClosing : ( GREATER_THAN | SHIFT_RIGHT |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:383:1: genericTypeListClosing : (
+  // GREATER_THAN | SHIFT_RIGHT |
   // BIT_SHIFT_RIGHT | );
   public final JavaParser.genericTypeListClosing_return genericTypeListClosing()
       throws RecognitionException {
@@ -1935,7 +1988,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 12)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:387:5: ( GREATER_THAN | SHIFT_RIGHT | BIT_SHIFT_RIGHT | )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:387:5: ( GREATER_THAN |
+      // SHIFT_RIGHT | BIT_SHIFT_RIGHT | )
       int alt12 = 4;
       switch (input.LA(1)) {
         case GREATER_THAN:
@@ -2140,7 +2194,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "genericTypeParameter"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:393:1: genericTypeParameter : IDENT ( bound )? -> ^( IDENT ( bound
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:393:1: genericTypeParameter : IDENT (
+  // bound )? -> ^( IDENT ( bound
   // )? ) ;
   public final JavaParser.genericTypeParameter_return genericTypeParameter()
       throws RecognitionException {
@@ -2159,7 +2214,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 13)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:394:5: ( IDENT ( bound )? -> ^( IDENT ( bound )? ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:394:5: ( IDENT ( bound )? -> ^(
+      // IDENT ( bound )? ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:394:9: IDENT ( bound )?
       {
         IDENT41 = (Token) match(input, IDENT, FOLLOW_IDENT_in_genericTypeParameter5167);
@@ -2223,7 +2279,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 395:9: -> ^( IDENT ( bound )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:395:13: ^( IDENT ( bound )? )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:395:13: ^( IDENT ( bound )?
+            // )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 = (CommonTree) adaptor.becomeRoot(stream_IDENT.nextNode(), root_1);
@@ -2272,7 +2329,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "bound"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:398:1: bound : EXTENDS type ( AND type )* -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:398:1: bound : EXTENDS type ( AND
+  // type )* -> ^(
   // EXTENDS_BOUND_LIST[$EXTENDS, \"EXTENDS_BOUND_LIST\"] ( type )+ ) ;
   public final JavaParser.bound_return bound() throws RecognitionException {
     JavaParser.bound_return retval = new JavaParser.bound_return();
@@ -2295,7 +2353,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 14)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:399:5: ( EXTENDS type ( AND type )* -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:399:5: ( EXTENDS type ( AND type
+      // )* -> ^(
       // EXTENDS_BOUND_LIST[$EXTENDS, \"EXTENDS_BOUND_LIST\"] ( type )+ ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:399:9: EXTENDS type ( AND type )*
       {
@@ -2357,7 +2416,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 400:9: -> ^( EXTENDS_BOUND_LIST[$EXTENDS, \"EXTENDS_BOUND_LIST\"] ( type )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:400:13: ^( EXTENDS_BOUND_LIST[$EXTENDS,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:400:13: ^(
+            // EXTENDS_BOUND_LIST[$EXTENDS,
             // \"EXTENDS_BOUND_LIST\"] ( type )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -2414,7 +2474,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "enumTypeDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:403:1: enumTypeDeclaration[CommonTree modifiers] : ENUM IDENT (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:403:1: enumTypeDeclaration[CommonTree
+  // modifiers] : ENUM IDENT (
   // implementsClause )? enumBody -> ^( ENUM IDENT ( implementsClause )? enumBody ) ;
   public final JavaParser.enumTypeDeclaration_return enumTypeDeclaration(CommonTree modifiers)
       throws RecognitionException {
@@ -2441,9 +2502,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 15)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:404:5: ( ENUM IDENT ( implementsClause )? enumBody -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:404:5: ( ENUM IDENT (
+      // implementsClause )? enumBody -> ^(
       // ENUM IDENT ( implementsClause )? enumBody ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:404:9: ENUM IDENT ( implementsClause )? enumBody
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:404:9: ENUM IDENT (
+      // implementsClause )? enumBody
       {
         ENUM47 = (Token) match(input, ENUM, FOLLOW_ENUM_in_enumTypeDeclaration5263);
         if (state.failed) return retval;
@@ -2498,7 +2561,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 405:9: -> ^( ENUM IDENT ( implementsClause )? enumBody )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:405:13: ^( ENUM IDENT ( implementsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:405:13: ^( ENUM IDENT (
+            // implementsClause )?
             // enumBody )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -2506,7 +2570,8 @@ public class JavaParser extends Parser {
 
               adaptor.addChild(root_1, modifiers);
               adaptor.addChild(root_1, stream_IDENT.nextNode());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:405:39: ( implementsClause )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:405:39: (
+              // implementsClause )?
               if (stream_implementsClause.hasNext()) {
                 adaptor.addChild(root_1, stream_implementsClause.nextTree());
               }
@@ -2551,7 +2616,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "enumBody"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:408:1: enumBody : LCURLY enumScopeDeclarations RCURLY -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:408:1: enumBody : LCURLY
+  // enumScopeDeclarations RCURLY -> ^(
   // ENUM_TOP_LEVEL_SCOPE[$LCURLY, \"ENUM_TOP_LEVEL_SCOPE\"] enumScopeDeclarations ) ;
   public final JavaParser.enumBody_return enumBody() throws RecognitionException {
     JavaParser.enumBody_return retval = new JavaParser.enumBody_return();
@@ -2573,9 +2639,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 16)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:409:5: ( LCURLY enumScopeDeclarations RCURLY -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:409:5: ( LCURLY
+      // enumScopeDeclarations RCURLY -> ^(
       // ENUM_TOP_LEVEL_SCOPE[$LCURLY, \"ENUM_TOP_LEVEL_SCOPE\"] enumScopeDeclarations ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:409:9: LCURLY enumScopeDeclarations RCURLY
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:409:9: LCURLY
+      // enumScopeDeclarations RCURLY
       {
         LCURLY51 = (Token) match(input, LCURLY, FOLLOW_LCURLY_in_enumBody5317);
         if (state.failed) return retval;
@@ -2606,9 +2674,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 410:9: -> ^( ENUM_TOP_LEVEL_SCOPE[$LCURLY, \"ENUM_TOP_LEVEL_SCOPE\"] enumScopeDeclarations )
+          // 410:9: -> ^( ENUM_TOP_LEVEL_SCOPE[$LCURLY, \"ENUM_TOP_LEVEL_SCOPE\"]
+          // enumScopeDeclarations )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:410:13: ^( ENUM_TOP_LEVEL_SCOPE[$LCURLY,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:410:13: ^(
+            // ENUM_TOP_LEVEL_SCOPE[$LCURLY,
             // \"ENUM_TOP_LEVEL_SCOPE\"] enumScopeDeclarations )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -2660,7 +2730,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "enumScopeDeclarations"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:413:1: enumScopeDeclarations : enumConstants ( COMMA )? (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:413:1: enumScopeDeclarations :
+  // enumConstants ( COMMA )? (
   // enumClassScopeDeclarations )? ;
   public final JavaParser.enumScopeDeclarations_return enumScopeDeclarations()
       throws RecognitionException {
@@ -2680,7 +2751,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 17)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:414:5: ( enumConstants ( COMMA )? (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:414:5: ( enumConstants ( COMMA )?
+      // (
       // enumClassScopeDeclarations )? )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:414:9: enumConstants ( COMMA )? (
       // enumClassScopeDeclarations )?
@@ -2710,7 +2782,8 @@ public class JavaParser extends Parser {
             break;
         }
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:414:33: ( enumClassScopeDeclarations )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:414:33: (
+        // enumClassScopeDeclarations )?
         int alt17 = 2;
         int LA17_0 = input.LA(1);
 
@@ -2719,7 +2792,8 @@ public class JavaParser extends Parser {
         }
         switch (alt17) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: enumClassScopeDeclarations
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+            // enumClassScopeDeclarations
             {
               pushFollow(FOLLOW_enumClassScopeDeclarations_in_enumScopeDeclarations5366);
               enumClassScopeDeclarations56 = enumClassScopeDeclarations();
@@ -2763,8 +2837,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "enumClassScopeDeclarations"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:417:1: enumClassScopeDeclarations : SEMI ( classScopeDeclarations
-  // )* -> ^( CLASS_TOP_LEVEL_SCOPE[$SEMI, \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:417:1: enumClassScopeDeclarations :
+  // SEMI ( classScopeDeclarations
+  // )* -> ^( CLASS_TOP_LEVEL_SCOPE[$SEMI, \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* )
+  // ;
   public final JavaParser.enumClassScopeDeclarations_return enumClassScopeDeclarations()
       throws RecognitionException {
     JavaParser.enumClassScopeDeclarations_return retval =
@@ -2784,15 +2860,18 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 18)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:418:5: ( SEMI ( classScopeDeclarations )* -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:418:5: ( SEMI (
+      // classScopeDeclarations )* -> ^(
       // CLASS_TOP_LEVEL_SCOPE[$SEMI, \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:418:9: SEMI ( classScopeDeclarations )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:418:9: SEMI (
+      // classScopeDeclarations )*
       {
         SEMI57 = (Token) match(input, SEMI, FOLLOW_SEMI_in_enumClassScopeDeclarations5386);
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_SEMI.add(SEMI57);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:418:14: ( classScopeDeclarations )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:418:14: (
+        // classScopeDeclarations )*
         loop18:
         do {
           int alt18 = 2;
@@ -2823,7 +2902,8 @@ public class JavaParser extends Parser {
 
           switch (alt18) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: classScopeDeclarations
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+              // classScopeDeclarations
               {
                 pushFollow(FOLLOW_classScopeDeclarations_in_enumClassScopeDeclarations5388);
                 classScopeDeclarations58 = classScopeDeclarations();
@@ -2854,9 +2934,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 419:9: -> ^( CLASS_TOP_LEVEL_SCOPE[$SEMI, \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* )
+          // 419:9: -> ^( CLASS_TOP_LEVEL_SCOPE[$SEMI, \"CLASS_TOP_LEVEL_SCOPE\"] (
+          // classScopeDeclarations )* )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:419:13: ^( CLASS_TOP_LEVEL_SCOPE[$SEMI,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:419:13: ^(
+            // CLASS_TOP_LEVEL_SCOPE[$SEMI,
             // \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -2868,7 +2950,8 @@ public class JavaParser extends Parser {
                                   CLASS_TOP_LEVEL_SCOPE, SEMI57, "CLASS_TOP_LEVEL_SCOPE"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:419:69: ( classScopeDeclarations )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:419:69: (
+              // classScopeDeclarations )*
               while (stream_classScopeDeclarations.hasNext()) {
                 adaptor.addChild(root_1, stream_classScopeDeclarations.nextTree());
               }
@@ -2912,7 +2995,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "enumConstants"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:422:1: enumConstants : enumConstant ( COMMA enumConstant )* ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:422:1: enumConstants : enumConstant (
+  // COMMA enumConstant )* ;
   public final JavaParser.enumConstants_return enumConstants() throws RecognitionException {
     JavaParser.enumConstants_return retval = new JavaParser.enumConstants_return();
     retval.start = input.LT(1);
@@ -2930,8 +3014,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 19)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:423:5: ( enumConstant ( COMMA enumConstant )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:423:9: enumConstant ( COMMA enumConstant )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:423:5: ( enumConstant ( COMMA
+      // enumConstant )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:423:9: enumConstant ( COMMA
+      // enumConstant )*
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -2957,7 +3043,8 @@ public class JavaParser extends Parser {
 
           switch (alt19) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:423:23: COMMA enumConstant
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:423:23: COMMA
+              // enumConstant
               {
                 COMMA60 = (Token) match(input, COMMA, FOLLOW_COMMA_in_enumConstants5430);
                 if (state.failed) return retval;
@@ -3006,7 +3093,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "enumConstant"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:426:1: enumConstant : annotationList IDENT ( arguments )? (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:426:1: enumConstant : annotationList
+  // IDENT ( arguments )? (
   // classBody )? ;
   public final JavaParser.enumConstant_return enumConstant() throws RecognitionException {
     JavaParser.enumConstant_return retval = new JavaParser.enumConstant_return();
@@ -3027,8 +3115,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 20)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:427:5: ( annotationList IDENT ( arguments )? ( classBody )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:427:9: annotationList IDENT ( arguments )? ( classBody )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:427:5: ( annotationList IDENT (
+      // arguments )? ( classBody )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:427:9: annotationList IDENT (
+      // arguments )? ( classBody )?
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -3117,8 +3207,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "interfaceTypeDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:430:1: interfaceTypeDeclaration[CommonTree modifiers] : INTERFACE
-  // IDENT ( genericTypeParameterList )? ( interfaceExtendsClause )? interfaceBody -> ^( INTERFACE IDENT ( genericTypeParameterList )?
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:430:1:
+  // interfaceTypeDeclaration[CommonTree modifiers] : INTERFACE
+  // IDENT ( genericTypeParameterList )? ( interfaceExtendsClause )? interfaceBody -> ^( INTERFACE
+  // IDENT ( genericTypeParameterList )?
   // ( interfaceExtendsClause )? interfaceBody ) ;
   public final JavaParser.interfaceTypeDeclaration_return interfaceTypeDeclaration(
       CommonTree modifiers) throws RecognitionException {
@@ -3151,10 +3243,13 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 21)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:431:5: ( INTERFACE IDENT ( genericTypeParameterList )? (
-      // interfaceExtendsClause )? interfaceBody -> ^( INTERFACE IDENT ( genericTypeParameterList )? ( interfaceExtendsClause )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:431:5: ( INTERFACE IDENT (
+      // genericTypeParameterList )? (
+      // interfaceExtendsClause )? interfaceBody -> ^( INTERFACE IDENT ( genericTypeParameterList )?
+      // ( interfaceExtendsClause )?
       // interfaceBody ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:431:9: INTERFACE IDENT ( genericTypeParameterList )? (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:431:9: INTERFACE IDENT (
+      // genericTypeParameterList )? (
       // interfaceExtendsClause )? interfaceBody
       {
         INTERFACE66 =
@@ -3166,7 +3261,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_IDENT.add(IDENT67);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:431:25: ( genericTypeParameterList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:431:25: (
+        // genericTypeParameterList )?
         int alt22 = 2;
         int LA22_0 = input.LA(1);
 
@@ -3175,7 +3271,8 @@ public class JavaParser extends Parser {
         }
         switch (alt22) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeParameterList
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+            // genericTypeParameterList
             {
               pushFollow(FOLLOW_genericTypeParameterList_in_interfaceTypeDeclaration5495);
               genericTypeParameterList68 = genericTypeParameterList();
@@ -3188,7 +3285,8 @@ public class JavaParser extends Parser {
             break;
         }
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:431:51: ( interfaceExtendsClause )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:431:51: (
+        // interfaceExtendsClause )?
         int alt23 = 2;
         int LA23_0 = input.LA(1);
 
@@ -3218,7 +3316,8 @@ public class JavaParser extends Parser {
         if (state.backtracking == 0) stream_interfaceBody.add(interfaceBody70.getTree());
 
         // AST REWRITE
-        // elements: IDENT, genericTypeParameterList, INTERFACE, interfaceBody, interfaceExtendsClause
+        // elements: IDENT, genericTypeParameterList, INTERFACE, interfaceBody,
+        // interfaceExtendsClause
         // token labels:
         // rule labels: retval
         // token list labels:
@@ -3231,9 +3330,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 432:9: -> ^( INTERFACE IDENT ( genericTypeParameterList )? ( interfaceExtendsClause )? interfaceBody )
+          // 432:9: -> ^( INTERFACE IDENT ( genericTypeParameterList )? ( interfaceExtendsClause )?
+          // interfaceBody )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:432:13: ^( INTERFACE IDENT (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:432:13: ^( INTERFACE IDENT
+            // (
             // genericTypeParameterList )? ( interfaceExtendsClause )? interfaceBody )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -3241,12 +3342,14 @@ public class JavaParser extends Parser {
 
               adaptor.addChild(root_1, modifiers);
               adaptor.addChild(root_1, stream_IDENT.nextNode());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:432:44: ( genericTypeParameterList )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:432:44: (
+              // genericTypeParameterList )?
               if (stream_genericTypeParameterList.hasNext()) {
                 adaptor.addChild(root_1, stream_genericTypeParameterList.nextTree());
               }
               stream_genericTypeParameterList.reset();
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:432:70: ( interfaceExtendsClause )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:432:70: (
+              // interfaceExtendsClause )?
               if (stream_interfaceExtendsClause.hasNext()) {
                 adaptor.addChild(root_1, stream_interfaceExtendsClause.nextTree());
               }
@@ -3291,7 +3394,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "typeList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:435:1: typeList : type ( COMMA type )* ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:435:1: typeList : type ( COMMA type
+  // )* ;
   public final JavaParser.typeList_return typeList() throws RecognitionException {
     JavaParser.typeList_return retval = new JavaParser.typeList_return();
     retval.start = input.LT(1);
@@ -3381,7 +3485,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "classBody"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:439:1: classBody : LCURLY ( classScopeDeclarations )* RCURLY -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:439:1: classBody : LCURLY (
+  // classScopeDeclarations )* RCURLY -> ^(
   // CLASS_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* ) ;
   public final JavaParser.classBody_return classBody() throws RecognitionException {
     JavaParser.classBody_return retval = new JavaParser.classBody_return();
@@ -3403,15 +3508,18 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 23)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:440:5: ( LCURLY ( classScopeDeclarations )* RCURLY -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:440:5: ( LCURLY (
+      // classScopeDeclarations )* RCURLY -> ^(
       // CLASS_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:440:9: LCURLY ( classScopeDeclarations )* RCURLY
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:440:9: LCURLY (
+      // classScopeDeclarations )* RCURLY
       {
         LCURLY74 = (Token) match(input, LCURLY, FOLLOW_LCURLY_in_classBody5582);
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_LCURLY.add(LCURLY74);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:440:16: ( classScopeDeclarations )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:440:16: (
+        // classScopeDeclarations )*
         loop25:
         do {
           int alt25 = 2;
@@ -3442,7 +3550,8 @@ public class JavaParser extends Parser {
 
           switch (alt25) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: classScopeDeclarations
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+              // classScopeDeclarations
               {
                 pushFollow(FOLLOW_classScopeDeclarations_in_classBody5584);
                 classScopeDeclarations75 = classScopeDeclarations();
@@ -3477,9 +3586,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 441:9: -> ^( CLASS_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* )
+          // 441:9: -> ^( CLASS_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] (
+          // classScopeDeclarations )* )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:441:13: ^( CLASS_TOP_LEVEL_SCOPE[$LCURLY,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:441:13: ^(
+            // CLASS_TOP_LEVEL_SCOPE[$LCURLY,
             // \"CLASS_TOP_LEVEL_SCOPE\"] ( classScopeDeclarations )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -3491,7 +3602,8 @@ public class JavaParser extends Parser {
                                   CLASS_TOP_LEVEL_SCOPE, LCURLY74, "CLASS_TOP_LEVEL_SCOPE"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:441:71: ( classScopeDeclarations )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:441:71: (
+              // classScopeDeclarations )*
               while (stream_classScopeDeclarations.hasNext()) {
                 adaptor.addChild(root_1, stream_classScopeDeclarations.nextTree());
               }
@@ -3535,8 +3647,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "interfaceBody"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:444:1: interfaceBody : LCURLY ( interfaceScopeDeclarations )*
-  // RCURLY -> ^( INTERFACE_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( interfaceScopeDeclarations )* ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:444:1: interfaceBody : LCURLY (
+  // interfaceScopeDeclarations )*
+  // RCURLY -> ^( INTERFACE_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] (
+  // interfaceScopeDeclarations )* ) ;
   public final JavaParser.interfaceBody_return interfaceBody() throws RecognitionException {
     JavaParser.interfaceBody_return retval = new JavaParser.interfaceBody_return();
     retval.start = input.LT(1);
@@ -3557,15 +3671,19 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 24)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:445:5: ( LCURLY ( interfaceScopeDeclarations )* RCURLY ->
-      // ^( INTERFACE_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( interfaceScopeDeclarations )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:445:9: LCURLY ( interfaceScopeDeclarations )* RCURLY
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:445:5: ( LCURLY (
+      // interfaceScopeDeclarations )* RCURLY ->
+      // ^( INTERFACE_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] (
+      // interfaceScopeDeclarations )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:445:9: LCURLY (
+      // interfaceScopeDeclarations )* RCURLY
       {
         LCURLY77 = (Token) match(input, LCURLY, FOLLOW_LCURLY_in_interfaceBody5629);
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_LCURLY.add(LCURLY77);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:445:16: ( interfaceScopeDeclarations )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:445:16: (
+        // interfaceScopeDeclarations )*
         loop26:
         do {
           int alt26 = 2;
@@ -3595,7 +3713,8 @@ public class JavaParser extends Parser {
 
           switch (alt26) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: interfaceScopeDeclarations
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+              // interfaceScopeDeclarations
               {
                 pushFollow(FOLLOW_interfaceScopeDeclarations_in_interfaceBody5631);
                 interfaceScopeDeclarations78 = interfaceScopeDeclarations();
@@ -3630,9 +3749,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 446:9: -> ^( INTERFACE_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( interfaceScopeDeclarations )* )
+          // 446:9: -> ^( INTERFACE_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] (
+          // interfaceScopeDeclarations )* )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:446:13: ^( INTERFACE_TOP_LEVEL_SCOPE[$LCURLY,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:446:13: ^(
+            // INTERFACE_TOP_LEVEL_SCOPE[$LCURLY,
             // \"CLASS_TOP_LEVEL_SCOPE\"] ( interfaceScopeDeclarations )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -3644,7 +3765,8 @@ public class JavaParser extends Parser {
                                   INTERFACE_TOP_LEVEL_SCOPE, LCURLY77, "CLASS_TOP_LEVEL_SCOPE"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:446:75: ( interfaceScopeDeclarations )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:446:75: (
+              // interfaceScopeDeclarations )*
               while (stream_interfaceScopeDeclarations.hasNext()) {
                 adaptor.addChild(root_1, stream_interfaceScopeDeclarations.nextTree());
               }
@@ -3688,14 +3810,22 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "classScopeDeclarations"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:449:1: classScopeDeclarations : ( block -> ^(
-  // CLASS_INSTANCE_INITIALIZER block ) | STATIC block -> ^( CLASS_STATIC_INITIALIZER[$STATIC, \"CLASS_STATIC_INITIALIZER\"] block ) |
-  // modifierList ( ( genericTypeParameterList )? ( type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block |
-  // SEMI ) -> ^( FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList
-  // )? ( throwsClause )? ( block )? ) | VOID IDENT formalParameterList ( throwsClause )? ( block | SEMI ) -> ^( VOID_METHOD_DECL
-  // modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block )? ) | ident= IDENT
-  // formalParameterList ( throwsClause )? block -> ^( CONSTRUCTOR_DECL[$ident, \"CONSTRUCTOR_DECL\"] modifierList (
-  // genericTypeParameterList )? formalParameterList ( throwsClause )? block ) ) | type classFieldDeclaratorList SEMI -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:449:1: classScopeDeclarations : (
+  // block -> ^(
+  // CLASS_INSTANCE_INITIALIZER block ) | STATIC block -> ^( CLASS_STATIC_INITIALIZER[$STATIC,
+  // \"CLASS_STATIC_INITIALIZER\"] block ) |
+  // modifierList ( ( genericTypeParameterList )? ( type IDENT formalParameterList (
+  // arrayDeclaratorList )? ( throwsClause )? ( block |
+  // SEMI ) -> ^( FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
+  // formalParameterList ( arrayDeclaratorList
+  // )? ( throwsClause )? ( block )? ) | VOID IDENT formalParameterList ( throwsClause )? ( block |
+  // SEMI ) -> ^( VOID_METHOD_DECL
+  // modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block
+  // )? ) | ident= IDENT
+  // formalParameterList ( throwsClause )? block -> ^( CONSTRUCTOR_DECL[$ident,
+  // \"CONSTRUCTOR_DECL\"] modifierList (
+  // genericTypeParameterList )? formalParameterList ( throwsClause )? block ) ) | type
+  // classFieldDeclaratorList SEMI -> ^(
   // VAR_DECLARATION modifierList type classFieldDeclaratorList ) ) | typeDeclaration | SEMI );
   public final JavaParser.classScopeDeclarations_return classScopeDeclarations()
       throws RecognitionException {
@@ -3781,15 +3911,23 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 25)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:450:5: ( block -> ^( CLASS_INSTANCE_INITIALIZER block ) |
-      // STATIC block -> ^( CLASS_STATIC_INITIALIZER[$STATIC, \"CLASS_STATIC_INITIALIZER\"] block ) | modifierList ( (
-      // genericTypeParameterList )? ( type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI )
-      // -> ^( FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList
-      // )? ( throwsClause )? ( block )? ) | VOID IDENT formalParameterList ( throwsClause )? ( block | SEMI ) -> ^(
-      // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block )? ) |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:450:5: ( block -> ^(
+      // CLASS_INSTANCE_INITIALIZER block ) |
+      // STATIC block -> ^( CLASS_STATIC_INITIALIZER[$STATIC, \"CLASS_STATIC_INITIALIZER\"] block )
+      // | modifierList ( (
+      // genericTypeParameterList )? ( type IDENT formalParameterList ( arrayDeclaratorList )? (
+      // throwsClause )? ( block | SEMI )
+      // -> ^( FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
+      // formalParameterList ( arrayDeclaratorList
+      // )? ( throwsClause )? ( block )? ) | VOID IDENT formalParameterList ( throwsClause )? (
+      // block | SEMI ) -> ^(
+      // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList (
+      // throwsClause )? ( block )? ) |
       // ident= IDENT formalParameterList ( throwsClause )? block -> ^( CONSTRUCTOR_DECL[$ident,
-      // \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )? formalParameterList ( throwsClause )? block ) ) | type
-      // classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList ) ) | typeDeclaration | SEMI )
+      // \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )? formalParameterList (
+      // throwsClause )? block ) ) | type
+      // classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type
+      // classFieldDeclaratorList ) ) | typeDeclaration | SEMI )
       int alt36 = 5;
       alt36 = dfa36.predict(input);
       switch (alt36) {
@@ -3819,7 +3957,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 450:25: -> ^( CLASS_INSTANCE_INITIALIZER block )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:450:29: ^( CLASS_INSTANCE_INITIALIZER block )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:450:29: ^(
+                // CLASS_INSTANCE_INITIALIZER block )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 =
@@ -3868,7 +4007,8 @@ public class JavaParser extends Parser {
                       adaptor, "rule retval", retval != null ? retval.tree : null);
 
               root_0 = (CommonTree) adaptor.nil();
-              // 451:25: -> ^( CLASS_STATIC_INITIALIZER[$STATIC, \"CLASS_STATIC_INITIALIZER\"] block )
+              // 451:25: -> ^( CLASS_STATIC_INITIALIZER[$STATIC, \"CLASS_STATIC_INITIALIZER\"] block
+              // )
               {
                 // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:451:29: ^(
                 // CLASS_STATIC_INITIALIZER[$STATIC, \"CLASS_STATIC_INITIALIZER\"] block )
@@ -3895,14 +4035,22 @@ public class JavaParser extends Parser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:452:9: modifierList ( ( genericTypeParameterList )
-          // ? ( type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) -> ^(
-          // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT formalParameterList (
-          // arrayDeclaratorList )? ( throwsClause )? ( block )? ) | VOID IDENT formalParameterList ( throwsClause )? ( block |
-          // SEMI ) -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause
-          // )? ( block )? ) | ident= IDENT formalParameterList ( throwsClause )? block -> ^( CONSTRUCTOR_DECL[$ident,
-          // \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )? formalParameterList ( throwsClause )? block ) ) |
-          // type classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList ) )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:452:9: modifierList ( (
+          // genericTypeParameterList )
+          // ? ( type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block |
+          // SEMI ) -> ^(
+          // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
+          // formalParameterList (
+          // arrayDeclaratorList )? ( throwsClause )? ( block )? ) | VOID IDENT formalParameterList
+          // ( throwsClause )? ( block |
+          // SEMI ) -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT
+          // formalParameterList ( throwsClause
+          // )? ( block )? ) | ident= IDENT formalParameterList ( throwsClause )? block -> ^(
+          // CONSTRUCTOR_DECL[$ident,
+          // \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )? formalParameterList (
+          // throwsClause )? block ) ) |
+          // type classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type
+          // classFieldDeclaratorList ) )
           {
             pushFollow(FOLLOW_modifierList_in_classScopeDeclarations5726);
             modifierList83 = modifierList();
@@ -3910,14 +4058,21 @@ public class JavaParser extends Parser {
             state._fsp--;
             if (state.failed) return retval;
             if (state.backtracking == 0) stream_modifierList.add(modifierList83.getTree());
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:9: ( ( genericTypeParameterList )? ( type
-            // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) -> ^( FUNCTION_METHOD_DECL
-            // modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause
-            // )? ( block )? ) | VOID IDENT formalParameterList ( throwsClause )? ( block | SEMI ) -> ^( VOID_METHOD_DECL
-            // modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block )? ) | ident= IDENT
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:9: ( (
+            // genericTypeParameterList )? ( type
+            // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI )
+            // -> ^( FUNCTION_METHOD_DECL
+            // modifierList ( genericTypeParameterList )? type IDENT formalParameterList (
+            // arrayDeclaratorList )? ( throwsClause
+            // )? ( block )? ) | VOID IDENT formalParameterList ( throwsClause )? ( block | SEMI )
+            // -> ^( VOID_METHOD_DECL
+            // modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause
+            // )? ( block )? ) | ident= IDENT
             // formalParameterList ( throwsClause )? block -> ^( CONSTRUCTOR_DECL[$ident,
-            // \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )? formalParameterList ( throwsClause )? block ) ) |
-            // type classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList ) )
+            // \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )? formalParameterList
+            // ( throwsClause )? block ) ) |
+            // type classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type
+            // classFieldDeclaratorList ) )
             int alt35 = 2;
             switch (input.LA(1)) {
               case LESS_THAN:
@@ -3983,16 +4138,24 @@ public class JavaParser extends Parser {
 
             switch (alt35) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( genericTypeParameterList )? (
-                // type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) -> ^(
-                // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT formalParameterList (
-                // arrayDeclaratorList )? ( throwsClause )? ( block )? ) | VOID IDENT formalParameterList ( throwsClause )? (
-                // block | SEMI ) -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList
-                // ( throwsClause )? ( block )? ) | ident= IDENT formalParameterList ( throwsClause )? block -> ^(
-                // CONSTRUCTOR_DECL[$ident, \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )?
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: (
+                // genericTypeParameterList )? (
+                // type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block
+                // | SEMI ) -> ^(
+                // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
+                // formalParameterList (
+                // arrayDeclaratorList )? ( throwsClause )? ( block )? ) | VOID IDENT
+                // formalParameterList ( throwsClause )? (
+                // block | SEMI ) -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )?
+                // IDENT formalParameterList
+                // ( throwsClause )? ( block )? ) | ident= IDENT formalParameterList ( throwsClause
+                // )? block -> ^(
+                // CONSTRUCTOR_DECL[$ident, \"CONSTRUCTOR_DECL\"] modifierList (
+                // genericTypeParameterList )?
                 // formalParameterList ( throwsClause )? block ) )
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( genericTypeParameterList )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: (
+                  // genericTypeParameterList )?
                   int alt27 = 2;
                   int LA27_0 = input.LA(1);
 
@@ -4001,7 +4164,8 @@ public class JavaParser extends Parser {
                   }
                   switch (alt27) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeParameterList
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                      // genericTypeParameterList
                       {
                         pushFollow(FOLLOW_genericTypeParameterList_in_classScopeDeclarations5740);
                         genericTypeParameterList84 = genericTypeParameterList();
@@ -4014,13 +4178,20 @@ public class JavaParser extends Parser {
                       break;
                   }
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:13: ( type IDENT formalParameterList (
-                  // arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) -> ^( FUNCTION_METHOD_DECL modifierList (
-                  // genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? (
-                  // block )? ) | VOID IDENT formalParameterList ( throwsClause )? ( block | SEMI ) -> ^( VOID_METHOD_DECL
-                  // modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block )? ) |
-                  // ident= IDENT formalParameterList ( throwsClause )? block -> ^( CONSTRUCTOR_DECL[$ident,
-                  // \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )? formalParameterList ( throwsClause )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:13: ( type IDENT
+                  // formalParameterList (
+                  // arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) -> ^(
+                  // FUNCTION_METHOD_DECL modifierList (
+                  // genericTypeParameterList )? type IDENT formalParameterList (
+                  // arrayDeclaratorList )? ( throwsClause )? (
+                  // block )? ) | VOID IDENT formalParameterList ( throwsClause )? ( block | SEMI )
+                  // -> ^( VOID_METHOD_DECL
+                  // modifierList ( genericTypeParameterList )? IDENT formalParameterList (
+                  // throwsClause )? ( block )? ) |
+                  // ident= IDENT formalParameterList ( throwsClause )? block -> ^(
+                  // CONSTRUCTOR_DECL[$ident,
+                  // \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )?
+                  // formalParameterList ( throwsClause )?
                   // block ) )
                   int alt34 = 3;
                   switch (input.LA(1)) {
@@ -4075,8 +4246,10 @@ public class JavaParser extends Parser {
 
                   switch (alt34) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:17: type IDENT
-                      // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI )
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:17: type
+                      // IDENT
+                      // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block |
+                      // SEMI )
                       {
                         pushFollow(FOLLOW_type_in_classScopeDeclarations5759);
                         type85 = type();
@@ -4096,7 +4269,8 @@ public class JavaParser extends Parser {
                         if (state.failed) return retval;
                         if (state.backtracking == 0)
                           stream_formalParameterList.add(formalParameterList87.getTree());
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:48: ( arrayDeclaratorList )?
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:48: (
+                        // arrayDeclaratorList )?
                         int alt28 = 2;
                         int LA28_0 = input.LA(1);
 
@@ -4105,7 +4279,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt28) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: arrayDeclaratorList
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                            // arrayDeclaratorList
                             {
                               pushFollow(FOLLOW_arrayDeclaratorList_in_classScopeDeclarations5765);
                               arrayDeclaratorList88 = arrayDeclaratorList();
@@ -4118,7 +4293,8 @@ public class JavaParser extends Parser {
                             break;
                         }
 
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:69: ( throwsClause )?
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:69: (
+                        // throwsClause )?
                         int alt29 = 2;
                         int LA29_0 = input.LA(1);
 
@@ -4127,7 +4303,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt29) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: throwsClause
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                            // throwsClause
                             {
                               pushFollow(FOLLOW_throwsClause_in_classScopeDeclarations5768);
                               throwsClause89 = throwsClause();
@@ -4140,7 +4317,8 @@ public class JavaParser extends Parser {
                             break;
                         }
 
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:83: ( block | SEMI )
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:83: ( block
+                        // | SEMI )
                         int alt30 = 2;
                         int LA30_0 = input.LA(1);
 
@@ -4159,7 +4337,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt30) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:84: block
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:84:
+                            // block
                             {
                               pushFollow(FOLLOW_block_in_classScopeDeclarations5772);
                               block90 = block();
@@ -4170,7 +4349,8 @@ public class JavaParser extends Parser {
                             }
                             break;
                           case 2:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:92: SEMI
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:92:
+                            // SEMI
                             {
                               SEMI91 =
                                   (Token)
@@ -4182,7 +4362,8 @@ public class JavaParser extends Parser {
                         }
 
                         // AST REWRITE
-                        // elements: formalParameterList, arrayDeclaratorList, modifierList, type, genericTypeParameterList,
+                        // elements: formalParameterList, arrayDeclaratorList, modifierList, type,
+                        // genericTypeParameterList,
                         // block, throwsClause, IDENT
                         // token labels:
                         // rule labels: retval
@@ -4196,12 +4377,16 @@ public class JavaParser extends Parser {
                                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
                           root_0 = (CommonTree) adaptor.nil();
-                          // 455:17: -> ^( FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
-                          // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block )? )
+                          // 455:17: -> ^( FUNCTION_METHOD_DECL modifierList (
+                          // genericTypeParameterList )? type IDENT
+                          // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block
+                          // )? )
                           {
                             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:455:21: ^(
-                            // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
-                            // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block )? )
+                            // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type
+                            // IDENT
+                            // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? (
+                            // block )? )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
                               root_1 =
@@ -4223,19 +4408,22 @@ public class JavaParser extends Parser {
                               adaptor.addChild(root_1, stream_type.nextTree());
                               adaptor.addChild(root_1, stream_IDENT.nextNode());
                               adaptor.addChild(root_1, stream_formalParameterList.nextTree());
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:455:114: (
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:455:114:
+                              // (
                               // arrayDeclaratorList )?
                               if (stream_arrayDeclaratorList.hasNext()) {
                                 adaptor.addChild(root_1, stream_arrayDeclaratorList.nextTree());
                               }
                               stream_arrayDeclaratorList.reset();
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:455:135: (
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:455:135:
+                              // (
                               // throwsClause )?
                               if (stream_throwsClause.hasNext()) {
                                 adaptor.addChild(root_1, stream_throwsClause.nextTree());
                               }
                               stream_throwsClause.reset();
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:455:149: ( block )?
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:455:149:
+                              // ( block )?
                               if (stream_block.hasNext()) {
                                 adaptor.addChild(root_1, stream_block.nextTree());
                               }
@@ -4250,7 +4438,8 @@ public class JavaParser extends Parser {
                       }
                       break;
                     case 2:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:17: VOID IDENT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:17: VOID
+                      // IDENT
                       // formalParameterList ( throwsClause )? ( block | SEMI )
                       {
                         VOID92 =
@@ -4270,7 +4459,8 @@ public class JavaParser extends Parser {
                         if (state.failed) return retval;
                         if (state.backtracking == 0)
                           stream_formalParameterList.add(formalParameterList94.getTree());
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:48: ( throwsClause )?
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:48: (
+                        // throwsClause )?
                         int alt31 = 2;
                         int LA31_0 = input.LA(1);
 
@@ -4279,7 +4469,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt31) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: throwsClause
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                            // throwsClause
                             {
                               pushFollow(FOLLOW_throwsClause_in_classScopeDeclarations5844);
                               throwsClause95 = throwsClause();
@@ -4292,7 +4483,8 @@ public class JavaParser extends Parser {
                             break;
                         }
 
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:62: ( block | SEMI )
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:62: ( block
+                        // | SEMI )
                         int alt32 = 2;
                         int LA32_0 = input.LA(1);
 
@@ -4311,7 +4503,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt32) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:63: block
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:63:
+                            // block
                             {
                               pushFollow(FOLLOW_block_in_classScopeDeclarations5848);
                               block96 = block();
@@ -4322,7 +4515,8 @@ public class JavaParser extends Parser {
                             }
                             break;
                           case 2:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:71: SEMI
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:71:
+                            // SEMI
                             {
                               SEMI97 =
                                   (Token)
@@ -4334,7 +4528,8 @@ public class JavaParser extends Parser {
                         }
 
                         // AST REWRITE
-                        // elements: throwsClause, formalParameterList, genericTypeParameterList, modifierList, block, IDENT
+                        // elements: throwsClause, formalParameterList, genericTypeParameterList,
+                        // modifierList, block, IDENT
                         // token labels:
                         // rule labels: retval
                         // token list labels:
@@ -4347,11 +4542,13 @@ public class JavaParser extends Parser {
                                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
                           root_0 = (CommonTree) adaptor.nil();
-                          // 457:17: -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT
+                          // 457:17: -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList
+                          // )? IDENT
                           // formalParameterList ( throwsClause )? ( block )? )
                           {
                             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:457:21: ^(
-                            // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList (
+                            // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT
+                            // formalParameterList (
                             // throwsClause )? ( block )? )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -4372,13 +4569,15 @@ public class JavaParser extends Parser {
                               stream_genericTypeParameterList.reset();
                               adaptor.addChild(root_1, stream_IDENT.nextNode());
                               adaptor.addChild(root_1, stream_formalParameterList.nextTree());
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:457:105: (
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:457:105:
+                              // (
                               // throwsClause )?
                               if (stream_throwsClause.hasNext()) {
                                 adaptor.addChild(root_1, stream_throwsClause.nextTree());
                               }
                               stream_throwsClause.reset();
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:457:119: ( block )?
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:457:119:
+                              // ( block )?
                               if (stream_block.hasNext()) {
                                 adaptor.addChild(root_1, stream_block.nextTree());
                               }
@@ -4393,7 +4592,8 @@ public class JavaParser extends Parser {
                       }
                       break;
                     case 3:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:17: ident= IDENT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:17: ident=
+                      // IDENT
                       // formalParameterList ( throwsClause )? block
                       {
                         ident =
@@ -4408,7 +4608,8 @@ public class JavaParser extends Parser {
                         if (state.failed) return retval;
                         if (state.backtracking == 0)
                           stream_formalParameterList.add(formalParameterList98.getTree());
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:49: ( throwsClause )?
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:49: (
+                        // throwsClause )?
                         int alt33 = 2;
                         int LA33_0 = input.LA(1);
 
@@ -4417,7 +4618,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt33) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: throwsClause
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                            // throwsClause
                             {
                               pushFollow(FOLLOW_throwsClause_in_classScopeDeclarations5915);
                               throwsClause99 = throwsClause();
@@ -4438,7 +4640,8 @@ public class JavaParser extends Parser {
                         if (state.backtracking == 0) stream_block.add(block100.getTree());
 
                         // AST REWRITE
-                        // elements: block, throwsClause, modifierList, genericTypeParameterList, formalParameterList
+                        // elements: block, throwsClause, modifierList, genericTypeParameterList,
+                        // formalParameterList
                         // token labels:
                         // rule labels: retval
                         // token list labels:
@@ -4451,11 +4654,14 @@ public class JavaParser extends Parser {
                                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
                           root_0 = (CommonTree) adaptor.nil();
-                          // 459:17: -> ^( CONSTRUCTOR_DECL[$ident, \"CONSTRUCTOR_DECL\"] modifierList (
-                          // genericTypeParameterList )? formalParameterList ( throwsClause )? block )
+                          // 459:17: -> ^( CONSTRUCTOR_DECL[$ident, \"CONSTRUCTOR_DECL\"]
+                          // modifierList (
+                          // genericTypeParameterList )? formalParameterList ( throwsClause )? block
+                          // )
                           {
                             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:459:21: ^(
-                            // CONSTRUCTOR_DECL[$ident, \"CONSTRUCTOR_DECL\"] modifierList ( genericTypeParameterList )?
+                            // CONSTRUCTOR_DECL[$ident, \"CONSTRUCTOR_DECL\"] modifierList (
+                            // genericTypeParameterList )?
                             // formalParameterList ( throwsClause )? block )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -4476,7 +4682,8 @@ public class JavaParser extends Parser {
                               }
                               stream_genericTypeParameterList.reset();
                               adaptor.addChild(root_1, stream_formalParameterList.nextTree());
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:459:127: (
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:459:127:
+                              // (
                               // throwsClause )?
                               if (stream_throwsClause.hasNext()) {
                                 adaptor.addChild(root_1, stream_throwsClause.nextTree());
@@ -4496,7 +4703,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:461:13: type classFieldDeclaratorList SEMI
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:461:13: type
+                // classFieldDeclaratorList SEMI
                 {
                   pushFollow(FOLLOW_type_in_classScopeDeclarations5982);
                   type101 = type();
@@ -4531,7 +4739,8 @@ public class JavaParser extends Parser {
                     root_0 = (CommonTree) adaptor.nil();
                     // 462:13: -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:462:17: ^( VAR_DECLARATION
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:462:17: ^(
+                      // VAR_DECLARATION
                       // modifierList type classFieldDeclaratorList )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -4609,11 +4818,16 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "interfaceScopeDeclarations"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:468:1: interfaceScopeDeclarations : ( modifierList ( (
-  // genericTypeParameterList )? ( type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI -> ^(
-  // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? (
-  // throwsClause )? ) | VOID IDENT formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL modifierList (
-  // genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ) ) | type interfaceFieldDeclaratorList SEMI -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:468:1: interfaceScopeDeclarations : (
+  // modifierList ( (
+  // genericTypeParameterList )? ( type IDENT formalParameterList ( arrayDeclaratorList )? (
+  // throwsClause )? SEMI -> ^(
+  // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT formalParameterList
+  // ( arrayDeclaratorList )? (
+  // throwsClause )? ) | VOID IDENT formalParameterList ( throwsClause )? SEMI -> ^(
+  // VOID_METHOD_DECL modifierList (
+  // genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ) ) | type
+  // interfaceFieldDeclaratorList SEMI -> ^(
   // VAR_DECLARATION modifierList type interfaceFieldDeclaratorList ) ) | typeDeclaration | SEMI );
   public final JavaParser.interfaceScopeDeclarations_return interfaceScopeDeclarations()
       throws RecognitionException {
@@ -4679,21 +4893,31 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 26)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:469:5: ( modifierList ( ( genericTypeParameterList )? (
-      // type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI -> ^( FUNCTION_METHOD_DECL modifierList (
-      // genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ) | VOID IDENT
-      // formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT
-      // formalParameterList ( throwsClause )? ) ) | type interfaceFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:469:5: ( modifierList ( (
+      // genericTypeParameterList )? (
+      // type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI -> ^(
+      // FUNCTION_METHOD_DECL modifierList (
+      // genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? (
+      // throwsClause )? ) | VOID IDENT
+      // formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL modifierList (
+      // genericTypeParameterList )? IDENT
+      // formalParameterList ( throwsClause )? ) ) | type interfaceFieldDeclaratorList SEMI -> ^(
+      // VAR_DECLARATION modifierList type
       // interfaceFieldDeclaratorList ) ) | typeDeclaration | SEMI )
       int alt43 = 3;
       alt43 = dfa43.predict(input);
       switch (alt43) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:469:9: modifierList ( ( genericTypeParameterList )
-          // ? ( type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI -> ^( FUNCTION_METHOD_DECL
-          // modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause
-          // )? ) | VOID IDENT formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL modifierList (
-          // genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ) ) | type interfaceFieldDeclaratorList
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:469:9: modifierList ( (
+          // genericTypeParameterList )
+          // ? ( type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI ->
+          // ^( FUNCTION_METHOD_DECL
+          // modifierList ( genericTypeParameterList )? type IDENT formalParameterList (
+          // arrayDeclaratorList )? ( throwsClause
+          // )? ) | VOID IDENT formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL
+          // modifierList (
+          // genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ) ) | type
+          // interfaceFieldDeclaratorList
           // SEMI -> ^( VAR_DECLARATION modifierList type interfaceFieldDeclaratorList ) )
           {
             pushFollow(FOLLOW_modifierList_in_interfaceScopeDeclarations6073);
@@ -4702,11 +4926,16 @@ public class JavaParser extends Parser {
             state._fsp--;
             if (state.failed) return retval;
             if (state.backtracking == 0) stream_modifierList.add(modifierList106.getTree());
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:9: ( ( genericTypeParameterList )? ( type
-            // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI -> ^( FUNCTION_METHOD_DECL modifierList
-            // ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ) | VOID
-            // IDENT formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )?
-            // IDENT formalParameterList ( throwsClause )? ) ) | type interfaceFieldDeclaratorList SEMI -> ^( VAR_DECLARATION
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:9: ( (
+            // genericTypeParameterList )? ( type
+            // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI -> ^(
+            // FUNCTION_METHOD_DECL modifierList
+            // ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )?
+            // ( throwsClause )? ) | VOID
+            // IDENT formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL modifierList
+            // ( genericTypeParameterList )?
+            // IDENT formalParameterList ( throwsClause )? ) ) | type interfaceFieldDeclaratorList
+            // SEMI -> ^( VAR_DECLARATION
             // modifierList type interfaceFieldDeclaratorList ) )
             int alt42 = 2;
             switch (input.LA(1)) {
@@ -4773,13 +5002,19 @@ public class JavaParser extends Parser {
 
             switch (alt42) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( genericTypeParameterList )? (
-                // type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI -> ^( FUNCTION_METHOD_DECL
-                // modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? (
-                // throwsClause )? ) | VOID IDENT formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL
-                // modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ) )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: (
+                // genericTypeParameterList )? (
+                // type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI ->
+                // ^( FUNCTION_METHOD_DECL
+                // modifierList ( genericTypeParameterList )? type IDENT formalParameterList (
+                // arrayDeclaratorList )? (
+                // throwsClause )? ) | VOID IDENT formalParameterList ( throwsClause )? SEMI -> ^(
+                // VOID_METHOD_DECL
+                // modifierList ( genericTypeParameterList )? IDENT formalParameterList (
+                // throwsClause )? ) )
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( genericTypeParameterList )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: (
+                  // genericTypeParameterList )?
                   int alt37 = 2;
                   int LA37_0 = input.LA(1);
 
@@ -4788,7 +5023,8 @@ public class JavaParser extends Parser {
                   }
                   switch (alt37) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeParameterList
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                      // genericTypeParameterList
                       {
                         pushFollow(
                             FOLLOW_genericTypeParameterList_in_interfaceScopeDeclarations6087);
@@ -4803,10 +5039,14 @@ public class JavaParser extends Parser {
                       break;
                   }
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:13: ( type IDENT formalParameterList (
-                  // arrayDeclaratorList )? ( throwsClause )? SEMI -> ^( FUNCTION_METHOD_DECL modifierList (
-                  // genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ) |
-                  // VOID IDENT formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL modifierList (
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:13: ( type IDENT
+                  // formalParameterList (
+                  // arrayDeclaratorList )? ( throwsClause )? SEMI -> ^( FUNCTION_METHOD_DECL
+                  // modifierList (
+                  // genericTypeParameterList )? type IDENT formalParameterList (
+                  // arrayDeclaratorList )? ( throwsClause )? ) |
+                  // VOID IDENT formalParameterList ( throwsClause )? SEMI -> ^( VOID_METHOD_DECL
+                  // modifierList (
                   // genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ) )
                   int alt41 = 2;
                   int LA41_0 = input.LA(1);
@@ -4833,7 +5073,8 @@ public class JavaParser extends Parser {
                   }
                   switch (alt41) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:17: type IDENT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:17: type
+                      // IDENT
                       // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI
                       {
                         pushFollow(FOLLOW_type_in_interfaceScopeDeclarations6106);
@@ -4855,7 +5096,8 @@ public class JavaParser extends Parser {
                         if (state.failed) return retval;
                         if (state.backtracking == 0)
                           stream_formalParameterList.add(formalParameterList110.getTree());
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:48: ( arrayDeclaratorList )?
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:48: (
+                        // arrayDeclaratorList )?
                         int alt38 = 2;
                         int LA38_0 = input.LA(1);
 
@@ -4864,7 +5106,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt38) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: arrayDeclaratorList
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                            // arrayDeclaratorList
                             {
                               pushFollow(
                                   FOLLOW_arrayDeclaratorList_in_interfaceScopeDeclarations6112);
@@ -4878,7 +5121,8 @@ public class JavaParser extends Parser {
                             break;
                         }
 
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:69: ( throwsClause )?
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:69: (
+                        // throwsClause )?
                         int alt39 = 2;
                         int LA39_0 = input.LA(1);
 
@@ -4887,7 +5131,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt39) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: throwsClause
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                            // throwsClause
                             {
                               pushFollow(FOLLOW_throwsClause_in_interfaceScopeDeclarations6115);
                               throwsClause112 = throwsClause();
@@ -4907,7 +5152,8 @@ public class JavaParser extends Parser {
                         if (state.backtracking == 0) stream_SEMI.add(SEMI113);
 
                         // AST REWRITE
-                        // elements: formalParameterList, genericTypeParameterList, throwsClause, arrayDeclaratorList,
+                        // elements: formalParameterList, genericTypeParameterList, throwsClause,
+                        // arrayDeclaratorList,
                         // modifierList, IDENT, type
                         // token labels:
                         // rule labels: retval
@@ -4921,11 +5167,13 @@ public class JavaParser extends Parser {
                                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
                           root_0 = (CommonTree) adaptor.nil();
-                          // 472:17: -> ^( FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
+                          // 472:17: -> ^( FUNCTION_METHOD_DECL modifierList (
+                          // genericTypeParameterList )? type IDENT
                           // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? )
                           {
                             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:472:21: ^(
-                            // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
+                            // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type
+                            // IDENT
                             // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -4948,13 +5196,15 @@ public class JavaParser extends Parser {
                               adaptor.addChild(root_1, stream_type.nextTree());
                               adaptor.addChild(root_1, stream_IDENT.nextNode());
                               adaptor.addChild(root_1, stream_formalParameterList.nextTree());
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:472:114: (
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:472:114:
+                              // (
                               // arrayDeclaratorList )?
                               if (stream_arrayDeclaratorList.hasNext()) {
                                 adaptor.addChild(root_1, stream_arrayDeclaratorList.nextTree());
                               }
                               stream_arrayDeclaratorList.reset();
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:472:135: (
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:472:135:
+                              // (
                               // throwsClause )?
                               if (stream_throwsClause.hasNext()) {
                                 adaptor.addChild(root_1, stream_throwsClause.nextTree());
@@ -4970,7 +5220,8 @@ public class JavaParser extends Parser {
                       }
                       break;
                     case 2:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:17: VOID IDENT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:17: VOID
+                      // IDENT
                       // formalParameterList ( throwsClause )? SEMI
                       {
                         VOID114 =
@@ -4992,7 +5243,8 @@ public class JavaParser extends Parser {
                         if (state.failed) return retval;
                         if (state.backtracking == 0)
                           stream_formalParameterList.add(formalParameterList116.getTree());
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:48: ( throwsClause )?
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:48: (
+                        // throwsClause )?
                         int alt40 = 2;
                         int LA40_0 = input.LA(1);
 
@@ -5001,7 +5253,8 @@ public class JavaParser extends Parser {
                         }
                         switch (alt40) {
                           case 1:
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: throwsClause
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                            // throwsClause
                             {
                               pushFollow(FOLLOW_throwsClause_in_interfaceScopeDeclarations6182);
                               throwsClause117 = throwsClause();
@@ -5021,7 +5274,8 @@ public class JavaParser extends Parser {
                         if (state.backtracking == 0) stream_SEMI.add(SEMI118);
 
                         // AST REWRITE
-                        // elements: formalParameterList, genericTypeParameterList, modifierList, throwsClause, IDENT
+                        // elements: formalParameterList, genericTypeParameterList, modifierList,
+                        // throwsClause, IDENT
                         // token labels:
                         // rule labels: retval
                         // token list labels:
@@ -5034,11 +5288,13 @@ public class JavaParser extends Parser {
                                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
                           root_0 = (CommonTree) adaptor.nil();
-                          // 474:17: -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT
+                          // 474:17: -> ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList
+                          // )? IDENT
                           // formalParameterList ( throwsClause )? )
                           {
                             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:474:21: ^(
-                            // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList (
+                            // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT
+                            // formalParameterList (
                             // throwsClause )? )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -5059,7 +5315,8 @@ public class JavaParser extends Parser {
                               stream_genericTypeParameterList.reset();
                               adaptor.addChild(root_1, stream_IDENT.nextNode());
                               adaptor.addChild(root_1, stream_formalParameterList.nextTree());
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:474:105: (
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:474:105:
+                              // (
                               // throwsClause )?
                               if (stream_throwsClause.hasNext()) {
                                 adaptor.addChild(root_1, stream_throwsClause.nextTree());
@@ -5078,7 +5335,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:476:13: type interfaceFieldDeclaratorList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:476:13: type
+                // interfaceFieldDeclaratorList
                 // SEMI
                 {
                   pushFollow(FOLLOW_type_in_interfaceScopeDeclarations6248);
@@ -5114,9 +5372,11 @@ public class JavaParser extends Parser {
                             adaptor, "rule retval", retval != null ? retval.tree : null);
 
                     root_0 = (CommonTree) adaptor.nil();
-                    // 477:13: -> ^( VAR_DECLARATION modifierList type interfaceFieldDeclaratorList )
+                    // 477:13: -> ^( VAR_DECLARATION modifierList type interfaceFieldDeclaratorList
+                    // )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:477:17: ^( VAR_DECLARATION
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:477:17: ^(
+                      // VAR_DECLARATION
                       // modifierList type interfaceFieldDeclaratorList )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -5194,7 +5454,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "classFieldDeclaratorList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:483:1: classFieldDeclaratorList : classFieldDeclarator ( COMMA
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:483:1: classFieldDeclaratorList :
+  // classFieldDeclarator ( COMMA
   // classFieldDeclarator )* -> ^( VAR_DECLARATOR_LIST ( classFieldDeclarator )+ ) ;
   public final JavaParser.classFieldDeclaratorList_return classFieldDeclaratorList()
       throws RecognitionException {
@@ -5217,9 +5478,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 27)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:484:5: ( classFieldDeclarator ( COMMA classFieldDeclarator
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:484:5: ( classFieldDeclarator (
+      // COMMA classFieldDeclarator
       // )* -> ^( VAR_DECLARATOR_LIST ( classFieldDeclarator )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:484:9: classFieldDeclarator ( COMMA classFieldDeclarator )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:484:9: classFieldDeclarator (
+      // COMMA classFieldDeclarator )*
       {
         pushFollow(FOLLOW_classFieldDeclarator_in_classFieldDeclaratorList6327);
         classFieldDeclarator124 = classFieldDeclarator();
@@ -5228,7 +5491,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           stream_classFieldDeclarator.add(classFieldDeclarator124.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:484:30: ( COMMA classFieldDeclarator )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:484:30: ( COMMA
+        // classFieldDeclarator )*
         loop44:
         do {
           int alt44 = 2;
@@ -5240,7 +5504,8 @@ public class JavaParser extends Parser {
 
           switch (alt44) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:484:31: COMMA classFieldDeclarator
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:484:31: COMMA
+              // classFieldDeclarator
               {
                 COMMA125 =
                     (Token) match(input, COMMA, FOLLOW_COMMA_in_classFieldDeclaratorList6330);
@@ -5278,7 +5543,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 485:9: -> ^( VAR_DECLARATOR_LIST ( classFieldDeclarator )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:485:13: ^( VAR_DECLARATOR_LIST (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:485:13: ^(
+            // VAR_DECLARATOR_LIST (
             // classFieldDeclarator )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -5334,7 +5600,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "classFieldDeclarator"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:488:1: classFieldDeclarator : variableDeclaratorId ( ASSIGN
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:488:1: classFieldDeclarator :
+  // variableDeclaratorId ( ASSIGN
   // variableInitializer )? -> ^( VAR_DECLARATOR variableDeclaratorId ( variableInitializer )? ) ;
   public final JavaParser.classFieldDeclarator_return classFieldDeclarator()
       throws RecognitionException {
@@ -5358,9 +5625,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 28)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:489:5: ( variableDeclaratorId ( ASSIGN variableInitializer
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:489:5: ( variableDeclaratorId (
+      // ASSIGN variableInitializer
       // )? -> ^( VAR_DECLARATOR variableDeclaratorId ( variableInitializer )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:489:9: variableDeclaratorId ( ASSIGN variableInitializer )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:489:9: variableDeclaratorId (
+      // ASSIGN variableInitializer )?
       {
         pushFollow(FOLLOW_variableDeclaratorId_in_classFieldDeclarator6371);
         variableDeclaratorId127 = variableDeclaratorId();
@@ -5369,7 +5638,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           stream_variableDeclaratorId.add(variableDeclaratorId127.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:489:30: ( ASSIGN variableInitializer )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:489:30: ( ASSIGN
+        // variableInitializer )?
         int alt45 = 2;
         int LA45_0 = input.LA(1);
 
@@ -5378,7 +5648,8 @@ public class JavaParser extends Parser {
         }
         switch (alt45) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:489:31: ASSIGN variableInitializer
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:489:31: ASSIGN
+            // variableInitializer
             {
               ASSIGN128 = (Token) match(input, ASSIGN, FOLLOW_ASSIGN_in_classFieldDeclarator6374);
               if (state.failed) return retval;
@@ -5411,7 +5682,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 490:9: -> ^( VAR_DECLARATOR variableDeclaratorId ( variableInitializer )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:490:13: ^( VAR_DECLARATOR variableDeclaratorId
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:490:13: ^( VAR_DECLARATOR
+            // variableDeclaratorId
             // ( variableInitializer )? )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -5421,7 +5693,8 @@ public class JavaParser extends Parser {
                           (CommonTree) adaptor.create(VAR_DECLARATOR, "VAR_DECLARATOR"), root_1);
 
               adaptor.addChild(root_1, stream_variableDeclaratorId.nextTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:490:51: ( variableInitializer )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:490:51: (
+              // variableInitializer )?
               if (stream_variableInitializer.hasNext()) {
                 adaptor.addChild(root_1, stream_variableInitializer.nextTree());
               }
@@ -5465,7 +5738,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "interfaceFieldDeclaratorList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:493:1: interfaceFieldDeclaratorList : interfaceFieldDeclarator (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:493:1: interfaceFieldDeclaratorList :
+  // interfaceFieldDeclarator (
   // COMMA interfaceFieldDeclarator )* -> ^( VAR_DECLARATOR_LIST ( interfaceFieldDeclarator )+ ) ;
   public final JavaParser.interfaceFieldDeclaratorList_return interfaceFieldDeclaratorList()
       throws RecognitionException {
@@ -5488,9 +5762,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 29)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:494:5: ( interfaceFieldDeclarator ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:494:5: ( interfaceFieldDeclarator
+      // ( COMMA
       // interfaceFieldDeclarator )* -> ^( VAR_DECLARATOR_LIST ( interfaceFieldDeclarator )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:494:9: interfaceFieldDeclarator ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:494:9: interfaceFieldDeclarator (
+      // COMMA
       // interfaceFieldDeclarator )*
       {
         pushFollow(FOLLOW_interfaceFieldDeclarator_in_interfaceFieldDeclaratorList6421);
@@ -5500,7 +5776,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           stream_interfaceFieldDeclarator.add(interfaceFieldDeclarator130.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:494:34: ( COMMA interfaceFieldDeclarator )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:494:34: ( COMMA
+        // interfaceFieldDeclarator )*
         loop46:
         do {
           int alt46 = 2;
@@ -5512,7 +5789,8 @@ public class JavaParser extends Parser {
 
           switch (alt46) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:494:35: COMMA interfaceFieldDeclarator
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:494:35: COMMA
+              // interfaceFieldDeclarator
               {
                 COMMA131 =
                     (Token) match(input, COMMA, FOLLOW_COMMA_in_interfaceFieldDeclaratorList6424);
@@ -5550,7 +5828,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 495:9: -> ^( VAR_DECLARATOR_LIST ( interfaceFieldDeclarator )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:495:13: ^( VAR_DECLARATOR_LIST (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:495:13: ^(
+            // VAR_DECLARATOR_LIST (
             // interfaceFieldDeclarator )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -5606,7 +5885,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "interfaceFieldDeclarator"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:498:1: interfaceFieldDeclarator : variableDeclaratorId ASSIGN
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:498:1: interfaceFieldDeclarator :
+  // variableDeclaratorId ASSIGN
   // variableInitializer -> ^( VAR_DECLARATOR variableDeclaratorId variableInitializer ) ;
   public final JavaParser.interfaceFieldDeclarator_return interfaceFieldDeclarator()
       throws RecognitionException {
@@ -5631,9 +5911,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 30)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:499:5: ( variableDeclaratorId ASSIGN variableInitializer
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:499:5: ( variableDeclaratorId
+      // ASSIGN variableInitializer
       // -> ^( VAR_DECLARATOR variableDeclaratorId variableInitializer ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:499:9: variableDeclaratorId ASSIGN variableInitializer
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:499:9: variableDeclaratorId
+      // ASSIGN variableInitializer
       {
         pushFollow(FOLLOW_variableDeclaratorId_in_interfaceFieldDeclarator6465);
         variableDeclaratorId133 = variableDeclaratorId();
@@ -5670,7 +5952,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 500:9: -> ^( VAR_DECLARATOR variableDeclaratorId variableInitializer )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:500:13: ^( VAR_DECLARATOR variableDeclaratorId
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:500:13: ^( VAR_DECLARATOR
+            // variableDeclaratorId
             // variableInitializer )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -5720,7 +6003,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "variableDeclaratorId"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:503:1: variableDeclaratorId : IDENT ( arrayDeclaratorList )? ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:503:1: variableDeclaratorId : IDENT (
+  // arrayDeclaratorList )? ;
   public final JavaParser.variableDeclaratorId_return variableDeclaratorId()
       throws RecognitionException {
     JavaParser.variableDeclaratorId_return retval = new JavaParser.variableDeclaratorId_return();
@@ -5737,8 +6021,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 31)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:504:5: ( IDENT ( arrayDeclaratorList )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:504:9: IDENT ( arrayDeclaratorList )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:504:5: ( IDENT (
+      // arrayDeclaratorList )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:504:9: IDENT (
+      // arrayDeclaratorList )?
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -5748,7 +6034,8 @@ public class JavaParser extends Parser {
           IDENT136_tree = (CommonTree) adaptor.create(IDENT136);
           root_0 = (CommonTree) adaptor.becomeRoot(IDENT136_tree, root_0);
         }
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:504:16: ( arrayDeclaratorList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:504:16: ( arrayDeclaratorList
+        // )?
         int alt47 = 2;
         int LA47_0 = input.LA(1);
 
@@ -5801,7 +6088,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "variableInitializer"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:507:1: variableInitializer : ( arrayInitializer | expression );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:507:1: variableInitializer : (
+  // arrayInitializer | expression );
   public final JavaParser.variableInitializer_return variableInitializer()
       throws RecognitionException {
     JavaParser.variableInitializer_return retval = new JavaParser.variableInitializer_return();
@@ -5817,7 +6105,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 32)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:508:5: ( arrayInitializer | expression )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:508:5: ( arrayInitializer |
+      // expression )
       int alt48 = 2;
       int LA48_0 = input.LA(1);
 
@@ -5912,7 +6201,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "arrayDeclarator"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:512:1: arrayDeclarator : LBRACK RBRACK -> ^( ARRAY_DECLARATOR ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:512:1: arrayDeclarator : LBRACK
+  // RBRACK -> ^( ARRAY_DECLARATOR ) ;
   public final JavaParser.arrayDeclarator_return arrayDeclarator() throws RecognitionException {
     JavaParser.arrayDeclarator_return retval = new JavaParser.arrayDeclarator_return();
     retval.start = input.LT(1);
@@ -5931,7 +6221,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 33)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:513:5: ( LBRACK RBRACK -> ^( ARRAY_DECLARATOR ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:513:5: ( LBRACK RBRACK -> ^(
+      // ARRAY_DECLARATOR ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:513:9: LBRACK RBRACK
       {
         LBRACK140 = (Token) match(input, LBRACK, FOLLOW_LBRACK_in_arrayDeclarator6563);
@@ -5958,7 +6249,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 514:9: -> ^( ARRAY_DECLARATOR )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:514:13: ^( ARRAY_DECLARATOR )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:514:13: ^( ARRAY_DECLARATOR
+            // )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -6005,7 +6297,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "arrayDeclaratorList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:517:1: arrayDeclaratorList : ( arrayDeclarator )+ -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:517:1: arrayDeclaratorList : (
+  // arrayDeclarator )+ -> ^(
   // ARRAY_DECLARATOR_LIST ( arrayDeclarator )+ ) ;
   public final JavaParser.arrayDeclaratorList_return arrayDeclaratorList()
       throws RecognitionException {
@@ -6022,7 +6315,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 34)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:518:5: ( ( arrayDeclarator )+ -> ^( ARRAY_DECLARATOR_LIST
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:518:5: ( ( arrayDeclarator )+ ->
+      // ^( ARRAY_DECLARATOR_LIST
       // ( arrayDeclarator )+ ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:518:9: ( arrayDeclarator )+
       {
@@ -6083,7 +6377,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 519:9: -> ^( ARRAY_DECLARATOR_LIST ( arrayDeclarator )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:519:13: ^( ARRAY_DECLARATOR_LIST (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:519:13: ^(
+            // ARRAY_DECLARATOR_LIST (
             // arrayDeclarator )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -6140,8 +6435,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "arrayInitializer"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:522:1: arrayInitializer : LCURLY ( variableInitializer ( COMMA
-  // variableInitializer )* ( COMMA )? )? RCURLY -> ^( ARRAY_INITIALIZER[$LCURLY, \"ARRAY_INITIALIZER\"] ( variableInitializer )* ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:522:1: arrayInitializer : LCURLY (
+  // variableInitializer ( COMMA
+  // variableInitializer )* ( COMMA )? )? RCURLY -> ^( ARRAY_INITIALIZER[$LCURLY,
+  // \"ARRAY_INITIALIZER\"] ( variableInitializer )* ) ;
   public final JavaParser.arrayInitializer_return arrayInitializer() throws RecognitionException {
     JavaParser.arrayInitializer_return retval = new JavaParser.arrayInitializer_return();
     retval.start = input.LT(1);
@@ -6169,17 +6466,21 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 35)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:5: ( LCURLY ( variableInitializer ( COMMA
-      // variableInitializer )* ( COMMA )? )? RCURLY -> ^( ARRAY_INITIALIZER[$LCURLY, \"ARRAY_INITIALIZER\"] ( variableInitializer
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:5: ( LCURLY (
+      // variableInitializer ( COMMA
+      // variableInitializer )* ( COMMA )? )? RCURLY -> ^( ARRAY_INITIALIZER[$LCURLY,
+      // \"ARRAY_INITIALIZER\"] ( variableInitializer
       // )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:9: LCURLY ( variableInitializer ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:9: LCURLY (
+      // variableInitializer ( COMMA
       // variableInitializer )* ( COMMA )? )? RCURLY
       {
         LCURLY143 = (Token) match(input, LCURLY, FOLLOW_LCURLY_in_arrayInitializer6644);
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_LCURLY.add(LCURLY143);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:16: ( variableInitializer ( COMMA
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:16: ( variableInitializer (
+        // COMMA
         // variableInitializer )* ( COMMA )? )?
         int alt52 = 2;
         int LA52_0 = input.LA(1);
@@ -6210,7 +6511,8 @@ public class JavaParser extends Parser {
         }
         switch (alt52) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:17: variableInitializer ( COMMA
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:17: variableInitializer
+            // ( COMMA
             // variableInitializer )* ( COMMA )?
             {
               pushFollow(FOLLOW_variableInitializer_in_arrayInitializer6647);
@@ -6220,7 +6522,8 @@ public class JavaParser extends Parser {
               if (state.failed) return retval;
               if (state.backtracking == 0)
                 stream_variableInitializer.add(variableInitializer144.getTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:37: ( COMMA variableInitializer )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:37: ( COMMA
+              // variableInitializer )*
               loop50:
               do {
                 int alt50 = 2;
@@ -6257,7 +6560,8 @@ public class JavaParser extends Parser {
 
                 switch (alt50) {
                   case 1:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:38: COMMA variableInitializer
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:523:38: COMMA
+                    // variableInitializer
                     {
                       COMMA145 = (Token) match(input, COMMA, FOLLOW_COMMA_in_arrayInitializer6650);
                       if (state.failed) return retval;
@@ -6317,9 +6621,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 524:9: -> ^( ARRAY_INITIALIZER[$LCURLY, \"ARRAY_INITIALIZER\"] ( variableInitializer )* )
+          // 524:9: -> ^( ARRAY_INITIALIZER[$LCURLY, \"ARRAY_INITIALIZER\"] ( variableInitializer )*
+          // )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:524:13: ^( ARRAY_INITIALIZER[$LCURLY,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:524:13: ^(
+            // ARRAY_INITIALIZER[$LCURLY,
             // \"ARRAY_INITIALIZER\"] ( variableInitializer )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -6330,7 +6636,8 @@ public class JavaParser extends Parser {
                               adaptor.create(ARRAY_INITIALIZER, LCURLY143, "ARRAY_INITIALIZER"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:524:63: ( variableInitializer )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:524:63: (
+              // variableInitializer )*
               while (stream_variableInitializer.hasNext()) {
                 adaptor.addChild(root_1, stream_variableInitializer.nextTree());
               }
@@ -6374,7 +6681,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "throwsClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:527:1: throwsClause : THROWS qualifiedIdentList -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:527:1: throwsClause : THROWS
+  // qualifiedIdentList -> ^(
   // THROWS_CLAUSE[$THROWS, \"THROWS_CLAUSE\"] qualifiedIdentList ) ;
   public final JavaParser.throwsClause_return throwsClause() throws RecognitionException {
     JavaParser.throwsClause_return retval = new JavaParser.throwsClause_return();
@@ -6393,7 +6701,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 36)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:528:5: ( THROWS qualifiedIdentList -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:528:5: ( THROWS
+      // qualifiedIdentList -> ^(
       // THROWS_CLAUSE[$THROWS, \"THROWS_CLAUSE\"] qualifiedIdentList ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:528:9: THROWS qualifiedIdentList
       {
@@ -6424,7 +6733,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 529:9: -> ^( THROWS_CLAUSE[$THROWS, \"THROWS_CLAUSE\"] qualifiedIdentList )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:529:13: ^( THROWS_CLAUSE[$THROWS,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:529:13: ^(
+            // THROWS_CLAUSE[$THROWS,
             // \"THROWS_CLAUSE\"] qualifiedIdentList )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -6474,7 +6784,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "modifierList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:532:1: modifierList : ( modifier )* -> ^( MODIFIER_LIST ( modifier
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:532:1: modifierList : ( modifier )*
+  // -> ^( MODIFIER_LIST ( modifier
   // )* ) ;
   public final JavaParser.modifierList_return modifierList() throws RecognitionException {
     JavaParser.modifierList_return retval = new JavaParser.modifierList_return();
@@ -6490,7 +6801,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 37)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:533:5: ( ( modifier )* -> ^( MODIFIER_LIST ( modifier )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:533:5: ( ( modifier )* -> ^(
+      // MODIFIER_LIST ( modifier )* ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:533:9: ( modifier )*
       {
         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:533:9: ( modifier )*
@@ -6551,7 +6863,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 534:9: -> ^( MODIFIER_LIST ( modifier )* )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:534:13: ^( MODIFIER_LIST ( modifier )* )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:534:13: ^( MODIFIER_LIST (
+            // modifier )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -6603,7 +6916,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "modifier"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:537:1: modifier : ( PUBLIC | PROTECTED | PRIVATE | STATIC |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:537:1: modifier : ( PUBLIC |
+  // PROTECTED | PRIVATE | STATIC |
   // ABSTRACT | NATIVE | SYNCHRONIZED | TRANSIENT | VOLATILE | STRICTFP | localModifier );
   public final JavaParser.modifier_return modifier() throws RecognitionException {
     JavaParser.modifier_return retval = new JavaParser.modifier_return();
@@ -6638,7 +6952,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 38)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:538:5: ( PUBLIC | PROTECTED | PRIVATE | STATIC | ABSTRACT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:538:5: ( PUBLIC | PROTECTED |
+      // PRIVATE | STATIC | ABSTRACT
       // | NATIVE | SYNCHRONIZED | TRANSIENT | VOLATILE | STRICTFP | localModifier )
       int alt54 = 11;
       switch (input.LA(1)) {
@@ -6884,7 +7199,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "localModifierList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:551:1: localModifierList : ( localModifier )* -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:551:1: localModifierList : (
+  // localModifier )* -> ^(
   // LOCAL_MODIFIER_LIST ( localModifier )* ) ;
   public final JavaParser.localModifierList_return localModifierList() throws RecognitionException {
     JavaParser.localModifierList_return retval = new JavaParser.localModifierList_return();
@@ -6900,7 +7216,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 39)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:552:5: ( ( localModifier )* -> ^( LOCAL_MODIFIER_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:552:5: ( ( localModifier )* -> ^(
+      // LOCAL_MODIFIER_LIST (
       // localModifier )* ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:552:9: ( localModifier )*
       {
@@ -6948,7 +7265,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 553:9: -> ^( LOCAL_MODIFIER_LIST ( localModifier )* )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:553:12: ^( LOCAL_MODIFIER_LIST ( localModifier
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:553:12: ^(
+            // LOCAL_MODIFIER_LIST ( localModifier
             // )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -6958,7 +7276,8 @@ public class JavaParser extends Parser {
                           (CommonTree) adaptor.create(LOCAL_MODIFIER_LIST, "LOCAL_MODIFIER_LIST"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:553:34: ( localModifier )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:553:34: ( localModifier
+              // )*
               while (stream_localModifier.hasNext()) {
                 adaptor.addChild(root_1, stream_localModifier.nextTree());
               }
@@ -7002,7 +7321,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "localModifier"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:556:1: localModifier : ( FINAL | annotation );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:556:1: localModifier : ( FINAL |
+  // annotation );
   public final JavaParser.localModifier_return localModifier() throws RecognitionException {
     JavaParser.localModifier_return retval = new JavaParser.localModifier_return();
     retval.start = input.LT(1);
@@ -7093,7 +7413,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "type"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:561:1: type : ( simpleType | objectType );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:561:1: type : ( simpleType |
+  // objectType );
   public final JavaParser.type_return type() throws RecognitionException {
     JavaParser.type_return retval = new JavaParser.type_return();
     retval.start = input.LT(1);
@@ -7108,7 +7429,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 41)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:562:5: ( simpleType | objectType )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:562:5: ( simpleType | objectType
+      // )
       int alt57 = 2;
       int LA57_0 = input.LA(1);
 
@@ -7189,7 +7511,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "simpleType"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:566:1: simpleType : primitiveType ( arrayDeclaratorList )? -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:566:1: simpleType : primitiveType (
+  // arrayDeclaratorList )? -> ^(
   // TYPE primitiveType ( arrayDeclaratorList )? ) ;
   public final JavaParser.simpleType_return simpleType() throws RecognitionException {
     JavaParser.simpleType_return retval = new JavaParser.simpleType_return();
@@ -7209,9 +7532,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 42)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:567:5: ( primitiveType ( arrayDeclaratorList )? -> ^( TYPE
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:567:5: ( primitiveType (
+      // arrayDeclaratorList )? -> ^( TYPE
       // primitiveType ( arrayDeclaratorList )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:567:9: primitiveType ( arrayDeclaratorList )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:567:9: primitiveType (
+      // arrayDeclaratorList )?
       {
         pushFollow(FOLLOW_primitiveType_in_simpleType6998);
         primitiveType168 = primitiveType();
@@ -7219,7 +7544,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_primitiveType.add(primitiveType168.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:567:23: ( arrayDeclaratorList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:567:23: ( arrayDeclaratorList
+        // )?
         int alt58 = 2;
         int LA58_0 = input.LA(1);
 
@@ -7265,7 +7591,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 568:9: -> ^( TYPE primitiveType ( arrayDeclaratorList )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:568:13: ^( TYPE primitiveType (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:568:13: ^( TYPE
+            // primitiveType (
             // arrayDeclaratorList )? )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -7274,7 +7601,8 @@ public class JavaParser extends Parser {
                       adaptor.becomeRoot((CommonTree) adaptor.create(TYPE, "TYPE"), root_1);
 
               adaptor.addChild(root_1, stream_primitiveType.nextTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:568:34: ( arrayDeclaratorList )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:568:34: (
+              // arrayDeclaratorList )?
               if (stream_arrayDeclaratorList.hasNext()) {
                 adaptor.addChild(root_1, stream_arrayDeclaratorList.nextTree());
               }
@@ -7318,7 +7646,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "objectType"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:571:1: objectType : qualifiedTypeIdent ( arrayDeclaratorList )? ->
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:571:1: objectType :
+  // qualifiedTypeIdent ( arrayDeclaratorList )? ->
   // ^( TYPE qualifiedTypeIdent ( arrayDeclaratorList )? ) ;
   public final JavaParser.objectType_return objectType() throws RecognitionException {
     JavaParser.objectType_return retval = new JavaParser.objectType_return();
@@ -7338,9 +7667,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 43)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:572:5: ( qualifiedTypeIdent ( arrayDeclaratorList )? -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:572:5: ( qualifiedTypeIdent (
+      // arrayDeclaratorList )? -> ^(
       // TYPE qualifiedTypeIdent ( arrayDeclaratorList )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:572:9: qualifiedTypeIdent ( arrayDeclaratorList )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:572:9: qualifiedTypeIdent (
+      // arrayDeclaratorList )?
       {
         pushFollow(FOLLOW_qualifiedTypeIdent_in_objectType7047);
         qualifiedTypeIdent170 = qualifiedTypeIdent();
@@ -7348,7 +7679,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_qualifiedTypeIdent.add(qualifiedTypeIdent170.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:572:28: ( arrayDeclaratorList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:572:28: ( arrayDeclaratorList
+        // )?
         int alt59 = 2;
         int LA59_0 = input.LA(1);
 
@@ -7390,7 +7722,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 573:9: -> ^( TYPE qualifiedTypeIdent ( arrayDeclaratorList )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:573:13: ^( TYPE qualifiedTypeIdent (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:573:13: ^( TYPE
+            // qualifiedTypeIdent (
             // arrayDeclaratorList )? )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -7399,7 +7732,8 @@ public class JavaParser extends Parser {
                       adaptor.becomeRoot((CommonTree) adaptor.create(TYPE, "TYPE"), root_1);
 
               adaptor.addChild(root_1, stream_qualifiedTypeIdent.nextTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:573:39: ( arrayDeclaratorList )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:573:39: (
+              // arrayDeclaratorList )?
               if (stream_arrayDeclaratorList.hasNext()) {
                 adaptor.addChild(root_1, stream_arrayDeclaratorList.nextTree());
               }
@@ -7443,7 +7777,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "objectTypeSimplified"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:576:1: objectTypeSimplified : qualifiedTypeIdentSimplified (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:576:1: objectTypeSimplified :
+  // qualifiedTypeIdentSimplified (
   // arrayDeclaratorList )? -> ^( TYPE qualifiedTypeIdentSimplified ( arrayDeclaratorList )? ) ;
   public final JavaParser.objectTypeSimplified_return objectTypeSimplified()
       throws RecognitionException {
@@ -7464,9 +7799,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 44)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:577:5: ( qualifiedTypeIdentSimplified (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:577:5: (
+      // qualifiedTypeIdentSimplified (
       // arrayDeclaratorList )? -> ^( TYPE qualifiedTypeIdentSimplified ( arrayDeclaratorList )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:577:9: qualifiedTypeIdentSimplified ( arrayDeclaratorList )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:577:9:
+      // qualifiedTypeIdentSimplified ( arrayDeclaratorList )?
       {
         pushFollow(FOLLOW_qualifiedTypeIdentSimplified_in_objectTypeSimplified7089);
         qualifiedTypeIdentSimplified172 = qualifiedTypeIdentSimplified();
@@ -7475,7 +7812,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           stream_qualifiedTypeIdentSimplified.add(qualifiedTypeIdentSimplified172.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:577:38: ( arrayDeclaratorList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:577:38: ( arrayDeclaratorList
+        // )?
         int alt60 = 2;
         int LA60_0 = input.LA(1);
 
@@ -7513,7 +7851,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 578:9: -> ^( TYPE qualifiedTypeIdentSimplified ( arrayDeclaratorList )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:578:13: ^( TYPE qualifiedTypeIdentSimplified (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:578:13: ^( TYPE
+            // qualifiedTypeIdentSimplified (
             // arrayDeclaratorList )? )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -7522,7 +7861,8 @@ public class JavaParser extends Parser {
                       adaptor.becomeRoot((CommonTree) adaptor.create(TYPE, "TYPE"), root_1);
 
               adaptor.addChild(root_1, stream_qualifiedTypeIdentSimplified.nextTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:578:49: ( arrayDeclaratorList )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:578:49: (
+              // arrayDeclaratorList )?
               if (stream_arrayDeclaratorList.hasNext()) {
                 adaptor.addChild(root_1, stream_arrayDeclaratorList.nextTree());
               }
@@ -7566,7 +7906,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "qualifiedTypeIdent"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:581:1: qualifiedTypeIdent : typeIdent ( DOT typeIdent )* -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:581:1: qualifiedTypeIdent : typeIdent
+  // ( DOT typeIdent )* -> ^(
   // QUALIFIED_TYPE_IDENT ( typeIdent )+ ) ;
   public final JavaParser.qualifiedTypeIdent_return qualifiedTypeIdent()
       throws RecognitionException {
@@ -7588,9 +7929,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 45)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:582:5: ( typeIdent ( DOT typeIdent )* -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:582:5: ( typeIdent ( DOT
+      // typeIdent )* -> ^(
       // QUALIFIED_TYPE_IDENT ( typeIdent )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:582:9: typeIdent ( DOT typeIdent )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:582:9: typeIdent ( DOT typeIdent
+      // )*
       {
         pushFollow(FOLLOW_typeIdent_in_qualifiedTypeIdent7131);
         typeIdent174 = typeIdent();
@@ -7650,7 +7993,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 583:9: -> ^( QUALIFIED_TYPE_IDENT ( typeIdent )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:583:13: ^( QUALIFIED_TYPE_IDENT ( typeIdent )+ )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:583:13: ^(
+            // QUALIFIED_TYPE_IDENT ( typeIdent )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -7705,7 +8049,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "qualifiedTypeIdentSimplified"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:586:1: qualifiedTypeIdentSimplified : typeIdentSimplified ( DOT
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:586:1: qualifiedTypeIdentSimplified :
+  // typeIdentSimplified ( DOT
   // typeIdentSimplified )* -> ^( QUALIFIED_TYPE_IDENT ( typeIdentSimplified )+ ) ;
   public final JavaParser.qualifiedTypeIdentSimplified_return qualifiedTypeIdentSimplified()
       throws RecognitionException {
@@ -7728,9 +8073,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 46)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:587:5: ( typeIdentSimplified ( DOT typeIdentSimplified )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:587:5: ( typeIdentSimplified (
+      // DOT typeIdentSimplified )*
       // -> ^( QUALIFIED_TYPE_IDENT ( typeIdentSimplified )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:587:9: typeIdentSimplified ( DOT typeIdentSimplified )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:587:9: typeIdentSimplified ( DOT
+      // typeIdentSimplified )*
       {
         pushFollow(FOLLOW_typeIdentSimplified_in_qualifiedTypeIdentSimplified7176);
         typeIdentSimplified177 = typeIdentSimplified();
@@ -7739,7 +8086,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           stream_typeIdentSimplified.add(typeIdentSimplified177.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:587:29: ( DOT typeIdentSimplified )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:587:29: ( DOT
+        // typeIdentSimplified )*
         loop62:
         do {
           int alt62 = 2;
@@ -7751,7 +8099,8 @@ public class JavaParser extends Parser {
 
           switch (alt62) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:587:30: DOT typeIdentSimplified
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:587:30: DOT
+              // typeIdentSimplified
               {
                 DOT178 = (Token) match(input, DOT, FOLLOW_DOT_in_qualifiedTypeIdentSimplified7179);
                 if (state.failed) return retval;
@@ -7788,7 +8137,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 588:9: -> ^( QUALIFIED_TYPE_IDENT ( typeIdentSimplified )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:588:13: ^( QUALIFIED_TYPE_IDENT (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:588:13: ^(
+            // QUALIFIED_TYPE_IDENT (
             // typeIdentSimplified )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -7844,7 +8194,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "typeIdent"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:591:1: typeIdent : IDENT ( genericTypeArgumentList )? ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:591:1: typeIdent : IDENT (
+  // genericTypeArgumentList )? ;
   public final JavaParser.typeIdent_return typeIdent() throws RecognitionException {
     JavaParser.typeIdent_return retval = new JavaParser.typeIdent_return();
     retval.start = input.LT(1);
@@ -7860,8 +8211,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 47)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:592:5: ( IDENT ( genericTypeArgumentList )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:592:9: IDENT ( genericTypeArgumentList )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:592:5: ( IDENT (
+      // genericTypeArgumentList )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:592:9: IDENT (
+      // genericTypeArgumentList )?
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -7871,7 +8224,8 @@ public class JavaParser extends Parser {
           IDENT180_tree = (CommonTree) adaptor.create(IDENT180);
           root_0 = (CommonTree) adaptor.becomeRoot(IDENT180_tree, root_0);
         }
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:592:16: ( genericTypeArgumentList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:592:16: (
+        // genericTypeArgumentList )?
         int alt63 = 2;
         int LA63_0 = input.LA(1);
 
@@ -7880,7 +8234,8 @@ public class JavaParser extends Parser {
         }
         switch (alt63) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeArgumentList
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+            // genericTypeArgumentList
             {
               pushFollow(FOLLOW_genericTypeArgumentList_in_typeIdent7224);
               genericTypeArgumentList181 = genericTypeArgumentList();
@@ -7942,8 +8297,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 48)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:596:5: ( IDENT ( genericTypeArgumentListSimplified )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:596:9: IDENT ( genericTypeArgumentListSimplified )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:596:5: ( IDENT (
+      // genericTypeArgumentListSimplified )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:596:9: IDENT (
+      // genericTypeArgumentListSimplified )?
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -7953,7 +8310,8 @@ public class JavaParser extends Parser {
           IDENT182_tree = (CommonTree) adaptor.create(IDENT182);
           root_0 = (CommonTree) adaptor.becomeRoot(IDENT182_tree, root_0);
         }
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:596:16: ( genericTypeArgumentListSimplified )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:596:16: (
+        // genericTypeArgumentListSimplified )?
         int alt64 = 2;
         int LA64_0 = input.LA(1);
 
@@ -7962,7 +8320,8 @@ public class JavaParser extends Parser {
         }
         switch (alt64) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeArgumentListSimplified
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+            // genericTypeArgumentListSimplified
             {
               pushFollow(FOLLOW_genericTypeArgumentListSimplified_in_typeIdentSimplified7247);
               genericTypeArgumentListSimplified183 = genericTypeArgumentListSimplified();
@@ -8006,7 +8365,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "primitiveType"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:599:1: primitiveType : ( BOOLEAN | CHAR | BYTE | SHORT | INT |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:599:1: primitiveType : ( BOOLEAN |
+  // CHAR | BYTE | SHORT | INT |
   // LONG | FLOAT | DOUBLE );
   public final JavaParser.primitiveType_return primitiveType() throws RecognitionException {
     JavaParser.primitiveType_return retval = new JavaParser.primitiveType_return();
@@ -8022,7 +8382,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 49)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:600:5: ( BOOLEAN | CHAR | BYTE | SHORT | INT | LONG |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:600:5: ( BOOLEAN | CHAR | BYTE |
+      // SHORT | INT | LONG |
       // FLOAT | DOUBLE )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:
       {
@@ -8081,7 +8442,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "genericTypeArgumentList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:610:1: genericTypeArgumentList : LESS_THAN genericTypeArgument (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:610:1: genericTypeArgumentList :
+  // LESS_THAN genericTypeArgument (
   // COMMA genericTypeArgument )* genericTypeListClosing -> ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN,
   // \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgument )+ ) ;
   public final JavaParser.genericTypeArgumentList_return genericTypeArgumentList()
@@ -8113,10 +8475,12 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 50)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:5: ( LESS_THAN genericTypeArgument ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:5: ( LESS_THAN
+      // genericTypeArgument ( COMMA
       // genericTypeArgument )* genericTypeListClosing -> ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN,
       // \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgument )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:9: LESS_THAN genericTypeArgument ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:9: LESS_THAN
+      // genericTypeArgument ( COMMA
       // genericTypeArgument )* genericTypeListClosing
       {
         LESS_THAN185 =
@@ -8131,7 +8495,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           stream_genericTypeArgument.add(genericTypeArgument186.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:39: ( COMMA genericTypeArgument )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:39: ( COMMA
+        // genericTypeArgument )*
         loop65:
         do {
           int alt65 = 2;
@@ -8147,7 +8512,8 @@ public class JavaParser extends Parser {
 
           switch (alt65) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:40: COMMA genericTypeArgument
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:40: COMMA
+              // genericTypeArgument
               {
                 COMMA187 = (Token) match(input, COMMA, FOLLOW_COMMA_in_genericTypeArgumentList7361);
                 if (state.failed) return retval;
@@ -8190,9 +8556,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 612:9: -> ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN, \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgument )+ )
+          // 612:9: -> ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN, \"GENERIC_TYPE_ARG_LIST\"] (
+          // genericTypeArgument )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:612:13: ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:612:13: ^(
+            // GENERIC_TYPE_ARG_LIST[$LESS_THAN,
             // \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgument )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -8250,7 +8618,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "genericTypeArgument"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:615:1: genericTypeArgument : ( type | QUESTION (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:615:1: genericTypeArgument : ( type |
+  // QUESTION (
   // genericWildcardBoundType )? -> ^( QUESTION ( genericWildcardBoundType )? ) );
   public final JavaParser.genericTypeArgument_return genericTypeArgument()
       throws RecognitionException {
@@ -8272,7 +8641,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 51)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:616:5: ( type | QUESTION ( genericWildcardBoundType )? ->
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:616:5: ( type | QUESTION (
+      // genericWildcardBoundType )? ->
       // ^( QUESTION ( genericWildcardBoundType )? ) )
       int alt67 = 2;
       int LA67_0 = input.LA(1);
@@ -8312,14 +8682,16 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:617:9: QUESTION ( genericWildcardBoundType )?
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:617:9: QUESTION (
+          // genericWildcardBoundType )?
           {
             QUESTION191 =
                 (Token) match(input, QUESTION, FOLLOW_QUESTION_in_genericTypeArgument7415);
             if (state.failed) return retval;
             if (state.backtracking == 0) stream_QUESTION.add(QUESTION191);
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:617:18: ( genericWildcardBoundType )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:617:18: (
+            // genericWildcardBoundType )?
             int alt66 = 2;
             int LA66_0 = input.LA(1);
 
@@ -8361,7 +8733,8 @@ public class JavaParser extends Parser {
             }
             switch (alt66) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericWildcardBoundType
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                // genericWildcardBoundType
                 {
                   pushFollow(FOLLOW_genericWildcardBoundType_in_genericTypeArgument7417);
                   genericWildcardBoundType192 = genericWildcardBoundType();
@@ -8396,7 +8769,8 @@ public class JavaParser extends Parser {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_QUESTION.nextNode(), root_1);
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:618:24: ( genericWildcardBoundType )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:618:24: (
+                  // genericWildcardBoundType )?
                   if (stream_genericWildcardBoundType.hasNext()) {
                     adaptor.addChild(root_1, stream_genericWildcardBoundType.nextTree());
                   }
@@ -8441,7 +8815,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "genericWildcardBoundType"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:621:1: genericWildcardBoundType : ( EXTENDS | SUPER ) type ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:621:1: genericWildcardBoundType : (
+  // EXTENDS | SUPER ) type ;
   public final JavaParser.genericWildcardBoundType_return genericWildcardBoundType()
       throws RecognitionException {
     JavaParser.genericWildcardBoundType_return retval =
@@ -8459,7 +8834,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 52)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:622:5: ( ( EXTENDS | SUPER ) type )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:622:5: ( ( EXTENDS | SUPER ) type
+      // )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:622:9: ( EXTENDS | SUPER ) type
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -8519,9 +8895,12 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "genericTypeArgumentListSimplified"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:625:1: genericTypeArgumentListSimplified : LESS_THAN
-  // genericTypeArgumentSimplified ( COMMA genericTypeArgumentSimplified )* genericTypeListClosing -> ^(
-  // GENERIC_TYPE_ARG_LIST[$LESS_THAN, \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgumentSimplified )+ ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:625:1:
+  // genericTypeArgumentListSimplified : LESS_THAN
+  // genericTypeArgumentSimplified ( COMMA genericTypeArgumentSimplified )* genericTypeListClosing
+  // -> ^(
+  // GENERIC_TYPE_ARG_LIST[$LESS_THAN, \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgumentSimplified )+
+  // ) ;
   public final JavaParser.genericTypeArgumentListSimplified_return
       genericTypeArgumentListSimplified() throws RecognitionException {
     JavaParser.genericTypeArgumentListSimplified_return retval =
@@ -8551,10 +8930,13 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 53)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:626:5: ( LESS_THAN genericTypeArgumentSimplified ( COMMA
-      // genericTypeArgumentSimplified )* genericTypeListClosing -> ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN,
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:626:5: ( LESS_THAN
+      // genericTypeArgumentSimplified ( COMMA
+      // genericTypeArgumentSimplified )* genericTypeListClosing -> ^(
+      // GENERIC_TYPE_ARG_LIST[$LESS_THAN,
       // \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgumentSimplified )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:626:9: LESS_THAN genericTypeArgumentSimplified ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:626:9: LESS_THAN
+      // genericTypeArgumentSimplified ( COMMA
       // genericTypeArgumentSimplified )* genericTypeListClosing
       {
         LESS_THAN195 =
@@ -8570,7 +8952,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           stream_genericTypeArgumentSimplified.add(genericTypeArgumentSimplified196.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:626:49: ( COMMA genericTypeArgumentSimplified )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:626:49: ( COMMA
+        // genericTypeArgumentSimplified )*
         loop68:
         do {
           int alt68 = 2;
@@ -8582,7 +8965,8 @@ public class JavaParser extends Parser {
 
           switch (alt68) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:626:50: COMMA genericTypeArgumentSimplified
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:626:50: COMMA
+              // genericTypeArgumentSimplified
               {
                 COMMA197 =
                     (Token)
@@ -8629,9 +9013,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 627:9: -> ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN, \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgumentSimplified )+ )
+          // 627:9: -> ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN, \"GENERIC_TYPE_ARG_LIST\"] (
+          // genericTypeArgumentSimplified )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:627:13: ^( GENERIC_TYPE_ARG_LIST[$LESS_THAN,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:627:13: ^(
+            // GENERIC_TYPE_ARG_LIST[$LESS_THAN,
             // \"GENERIC_TYPE_ARG_LIST\"] ( genericTypeArgumentSimplified )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -8689,7 +9075,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "genericTypeArgumentSimplified"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:630:1: genericTypeArgumentSimplified : ( type | QUESTION );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:630:1: genericTypeArgumentSimplified
+  // : ( type | QUESTION );
   public final JavaParser.genericTypeArgumentSimplified_return genericTypeArgumentSimplified()
       throws RecognitionException {
     JavaParser.genericTypeArgumentSimplified_return retval =
@@ -8791,7 +9178,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "qualifiedIdentList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:635:1: qualifiedIdentList : qualifiedIdentifier ( COMMA
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:635:1: qualifiedIdentList :
+  // qualifiedIdentifier ( COMMA
   // qualifiedIdentifier )* ;
   public final JavaParser.qualifiedIdentList_return qualifiedIdentList()
       throws RecognitionException {
@@ -8811,8 +9199,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 55)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:636:5: ( qualifiedIdentifier ( COMMA qualifiedIdentifier )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:636:9: qualifiedIdentifier ( COMMA qualifiedIdentifier )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:636:5: ( qualifiedIdentifier (
+      // COMMA qualifiedIdentifier )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:636:9: qualifiedIdentifier (
+      // COMMA qualifiedIdentifier )*
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -8822,7 +9212,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, qualifiedIdentifier202.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:636:29: ( COMMA qualifiedIdentifier )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:636:29: ( COMMA
+        // qualifiedIdentifier )*
         loop70:
         do {
           int alt70 = 2;
@@ -8834,7 +9225,8 @@ public class JavaParser extends Parser {
 
           switch (alt70) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:636:30: COMMA qualifiedIdentifier
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:636:30: COMMA
+              // qualifiedIdentifier
               {
                 COMMA203 = (Token) match(input, COMMA, FOLLOW_COMMA_in_qualifiedIdentList7576);
                 if (state.failed) return retval;
@@ -8884,10 +9276,14 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "formalParameterList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:639:1: formalParameterList : LPAREN ( formalParameterStandardDecl
-  // ( COMMA formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? -> ^( FORMAL_PARAM_LIST[$LPAREN,
-  // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? ) | formalParameterVarArgDecl -> ^(
-  // FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl ) | -> ^( FORMAL_PARAM_LIST[$LPAREN,
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:639:1: formalParameterList : LPAREN (
+  // formalParameterStandardDecl
+  // ( COMMA formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? -> ^(
+  // FORMAL_PARAM_LIST[$LPAREN,
+  // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? ) |
+  // formalParameterVarArgDecl -> ^(
+  // FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl ) | -> ^(
+  // FORMAL_PARAM_LIST[$LPAREN,
   // \"FORMAL_PARAM_LIST\"] ) ) RPAREN ;
   public final JavaParser.formalParameterList_return formalParameterList()
       throws RecognitionException {
@@ -8923,25 +9319,37 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 56)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:640:5: ( LPAREN ( formalParameterStandardDecl ( COMMA
-      // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? -> ^( FORMAL_PARAM_LIST[$LPAREN,
-      // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? ) | formalParameterVarArgDecl -> ^(
-      // FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl ) | -> ^( FORMAL_PARAM_LIST[$LPAREN,
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:640:5: ( LPAREN (
+      // formalParameterStandardDecl ( COMMA
+      // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? -> ^(
+      // FORMAL_PARAM_LIST[$LPAREN,
+      // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? ) |
+      // formalParameterVarArgDecl -> ^(
+      // FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl ) | -> ^(
+      // FORMAL_PARAM_LIST[$LPAREN,
       // \"FORMAL_PARAM_LIST\"] ) ) RPAREN )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:640:9: LPAREN ( formalParameterStandardDecl ( COMMA
-      // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? -> ^( FORMAL_PARAM_LIST[$LPAREN,
-      // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? ) | formalParameterVarArgDecl -> ^(
-      // FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl ) | -> ^( FORMAL_PARAM_LIST[$LPAREN,
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:640:9: LPAREN (
+      // formalParameterStandardDecl ( COMMA
+      // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? -> ^(
+      // FORMAL_PARAM_LIST[$LPAREN,
+      // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? ) |
+      // formalParameterVarArgDecl -> ^(
+      // FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl ) | -> ^(
+      // FORMAL_PARAM_LIST[$LPAREN,
       // \"FORMAL_PARAM_LIST\"] ) ) RPAREN
       {
         LPAREN205 = (Token) match(input, LPAREN, FOLLOW_LPAREN_in_formalParameterList7604);
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_LPAREN.add(LPAREN205);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:641:9: ( formalParameterStandardDecl ( COMMA
-        // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? -> ^( FORMAL_PARAM_LIST[$LPAREN,
-        // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? ) | formalParameterVarArgDecl
-        // -> ^( FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl ) | -> ^( FORMAL_PARAM_LIST[$LPAREN,
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:641:9: (
+        // formalParameterStandardDecl ( COMMA
+        // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? -> ^(
+        // FORMAL_PARAM_LIST[$LPAREN,
+        // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? )
+        // | formalParameterVarArgDecl
+        // -> ^( FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl ) | ->
+        // ^( FORMAL_PARAM_LIST[$LPAREN,
         // \"FORMAL_PARAM_LIST\"] ) )
         int alt73 = 3;
         switch (input.LA(1)) {
@@ -9045,7 +9453,8 @@ public class JavaParser extends Parser {
 
         switch (alt73) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:13: formalParameterStandardDecl ( COMMA
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:13:
+            // formalParameterStandardDecl ( COMMA
             // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )?
             {
               pushFollow(FOLLOW_formalParameterStandardDecl_in_formalParameterList7632);
@@ -9055,7 +9464,8 @@ public class JavaParser extends Parser {
               if (state.failed) return retval;
               if (state.backtracking == 0)
                 stream_formalParameterStandardDecl.add(formalParameterStandardDecl206.getTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:41: ( COMMA formalParameterStandardDecl )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:41: ( COMMA
+              // formalParameterStandardDecl )*
               loop71:
               do {
                 int alt71 = 2;
@@ -9095,7 +9505,8 @@ public class JavaParser extends Parser {
                 }
               } while (true);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:78: ( COMMA formalParameterVarArgDecl )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:78: ( COMMA
+              // formalParameterVarArgDecl )?
               int alt72 = 2;
               int LA72_0 = input.LA(1);
 
@@ -9104,7 +9515,8 @@ public class JavaParser extends Parser {
               }
               switch (alt72) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:79: COMMA formalParameterVarArgDecl
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:79: COMMA
+                  // formalParameterVarArgDecl
                   {
                     COMMA209 = (Token) match(input, COMMA, FOLLOW_COMMA_in_formalParameterList7642);
                     if (state.failed) return retval;
@@ -9135,11 +9547,14 @@ public class JavaParser extends Parser {
                         adaptor, "rule retval", retval != null ? retval.tree : null);
 
                 root_0 = (CommonTree) adaptor.nil();
-                // 643:13: -> ^( FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ (
+                // 643:13: -> ^( FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] (
+                // formalParameterStandardDecl )+ (
                 // formalParameterVarArgDecl )? )
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:643:17: ^( FORMAL_PARAM_LIST[$LPAREN,
-                  // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ ( formalParameterVarArgDecl )? )
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:643:17: ^(
+                  // FORMAL_PARAM_LIST[$LPAREN,
+                  // \"FORMAL_PARAM_LIST\"] ( formalParameterStandardDecl )+ (
+                  // formalParameterVarArgDecl )? )
                   {
                     CommonTree root_1 = (CommonTree) adaptor.nil();
                     root_1 =
@@ -9173,7 +9588,8 @@ public class JavaParser extends Parser {
             }
             break;
           case 2:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:645:13: formalParameterVarArgDecl
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:645:13:
+            // formalParameterVarArgDecl
             {
               pushFollow(FOLLOW_formalParameterVarArgDecl_in_formalParameterList7701);
               formalParameterVarArgDecl211 = formalParameterVarArgDecl();
@@ -9197,9 +9613,11 @@ public class JavaParser extends Parser {
                         adaptor, "rule retval", retval != null ? retval.tree : null);
 
                 root_0 = (CommonTree) adaptor.nil();
-                // 646:13: -> ^( FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl )
+                // 646:13: -> ^( FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"]
+                // formalParameterVarArgDecl )
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:646:17: ^( FORMAL_PARAM_LIST[$LPAREN,
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:646:17: ^(
+                  // FORMAL_PARAM_LIST[$LPAREN,
                   // \"FORMAL_PARAM_LIST\"] formalParameterVarArgDecl )
                   {
                     CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -9241,7 +9659,8 @@ public class JavaParser extends Parser {
                 root_0 = (CommonTree) adaptor.nil();
                 // 648:13: -> ^( FORMAL_PARAM_LIST[$LPAREN, \"FORMAL_PARAM_LIST\"] )
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:648:17: ^( FORMAL_PARAM_LIST[$LPAREN,
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:648:17: ^(
+                  // FORMAL_PARAM_LIST[$LPAREN,
                   // \"FORMAL_PARAM_LIST\"] )
                   {
                     CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -9298,8 +9717,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "formalParameterStandardDecl"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:653:1: formalParameterStandardDecl : localModifierList type
-  // variableDeclaratorId -> ^( FORMAL_PARAM_STD_DECL localModifierList type variableDeclaratorId ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:653:1: formalParameterStandardDecl :
+  // localModifierList type
+  // variableDeclaratorId -> ^( FORMAL_PARAM_STD_DECL localModifierList type variableDeclaratorId )
+  // ;
   public final JavaParser.formalParameterStandardDecl_return formalParameterStandardDecl()
       throws RecognitionException {
     JavaParser.formalParameterStandardDecl_return retval =
@@ -9323,9 +9744,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 57)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:654:5: ( localModifierList type variableDeclaratorId -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:654:5: ( localModifierList type
+      // variableDeclaratorId -> ^(
       // FORMAL_PARAM_STD_DECL localModifierList type variableDeclaratorId ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:654:9: localModifierList type variableDeclaratorId
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:654:9: localModifierList type
+      // variableDeclaratorId
       {
         pushFollow(FOLLOW_localModifierList_in_formalParameterStandardDecl7801);
         localModifierList213 = localModifierList();
@@ -9363,7 +9786,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 655:9: -> ^( FORMAL_PARAM_STD_DECL localModifierList type variableDeclaratorId )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:655:13: ^( FORMAL_PARAM_STD_DECL
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:655:13: ^(
+            // FORMAL_PARAM_STD_DECL
             // localModifierList type variableDeclaratorId )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -9416,8 +9840,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "formalParameterVarArgDecl"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:658:1: formalParameterVarArgDecl : localModifierList type ELLIPSIS
-  // variableDeclaratorId -> ^( FORMAL_PARAM_VARARG_DECL localModifierList type variableDeclaratorId ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:658:1: formalParameterVarArgDecl :
+  // localModifierList type ELLIPSIS
+  // variableDeclaratorId -> ^( FORMAL_PARAM_VARARG_DECL localModifierList type variableDeclaratorId
+  // ) ;
   public final JavaParser.formalParameterVarArgDecl_return formalParameterVarArgDecl()
       throws RecognitionException {
     JavaParser.formalParameterVarArgDecl_return retval =
@@ -9444,9 +9870,12 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 58)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:659:5: ( localModifierList type ELLIPSIS
-      // variableDeclaratorId -> ^( FORMAL_PARAM_VARARG_DECL localModifierList type variableDeclaratorId ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:659:9: localModifierList type ELLIPSIS variableDeclaratorId
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:659:5: ( localModifierList type
+      // ELLIPSIS
+      // variableDeclaratorId -> ^( FORMAL_PARAM_VARARG_DECL localModifierList type
+      // variableDeclaratorId ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:659:9: localModifierList type
+      // ELLIPSIS variableDeclaratorId
       {
         pushFollow(FOLLOW_localModifierList_in_formalParameterVarArgDecl7849);
         localModifierList216 = localModifierList();
@@ -9489,7 +9918,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 660:9: -> ^( FORMAL_PARAM_VARARG_DECL localModifierList type variableDeclaratorId )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:660:13: ^( FORMAL_PARAM_VARARG_DECL
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:660:13: ^(
+            // FORMAL_PARAM_VARARG_DECL
             // localModifierList type variableDeclaratorId )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -9542,7 +9972,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "qualifiedIdentifier"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:663:1: qualifiedIdentifier : ( IDENT -> IDENT ) ( DOT ident= IDENT
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:663:1: qualifiedIdentifier : ( IDENT
+  // -> IDENT ) ( DOT ident= IDENT
   // -> ^( DOT $qualifiedIdentifier $ident) )* ;
   public final JavaParser.qualifiedIdentifier_return qualifiedIdentifier()
       throws RecognitionException {
@@ -9565,9 +9996,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 59)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:664:5: ( ( IDENT -> IDENT ) ( DOT ident= IDENT -> ^( DOT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:664:5: ( ( IDENT -> IDENT ) ( DOT
+      // ident= IDENT -> ^( DOT
       // $qualifiedIdentifier $ident) )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:664:9: ( IDENT -> IDENT ) ( DOT ident= IDENT -> ^( DOT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:664:9: ( IDENT -> IDENT ) ( DOT
+      // ident= IDENT -> ^( DOT
       // $qualifiedIdentifier $ident) )*
       {
         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:664:9: ( IDENT -> IDENT )
@@ -9600,7 +10033,8 @@ public class JavaParser extends Parser {
           }
         }
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:666:9: ( DOT ident= IDENT -> ^( DOT
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:666:9: ( DOT ident= IDENT -> ^(
+        // DOT
         // $qualifiedIdentifier $ident) )*
         loop74:
         do {
@@ -9703,7 +10137,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:672:1: annotationList : ( annotation )* -> ^( ANNOTATION_LIST (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:672:1: annotationList : ( annotation
+  // )* -> ^( ANNOTATION_LIST (
   // annotation )* ) ;
   public final JavaParser.annotationList_return annotationList() throws RecognitionException {
     JavaParser.annotationList_return retval = new JavaParser.annotationList_return();
@@ -9719,7 +10154,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 60)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:673:5: ( ( annotation )* -> ^( ANNOTATION_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:673:5: ( ( annotation )* -> ^(
+      // ANNOTATION_LIST (
       // annotation )* ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:673:9: ( annotation )*
       {
@@ -9775,7 +10211,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 674:9: -> ^( ANNOTATION_LIST ( annotation )* )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:674:13: ^( ANNOTATION_LIST ( annotation )* )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:674:13: ^( ANNOTATION_LIST
+            // ( annotation )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -9827,7 +10264,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotation"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:677:1: annotation : AT qualifiedIdentifier ( annotationInit )? ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:677:1: annotation : AT
+  // qualifiedIdentifier ( annotationInit )? ;
   public final JavaParser.annotation_return annotation() throws RecognitionException {
     JavaParser.annotation_return retval = new JavaParser.annotation_return();
     retval.start = input.LT(1);
@@ -9845,8 +10283,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 61)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:678:5: ( AT qualifiedIdentifier ( annotationInit )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:678:9: AT qualifiedIdentifier ( annotationInit )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:678:5: ( AT qualifiedIdentifier (
+      // annotationInit )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:678:9: AT qualifiedIdentifier (
+      // annotationInit )?
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -9914,7 +10354,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationInit"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:681:1: annotationInit : LPAREN annotationInitializers RPAREN -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:681:1: annotationInit : LPAREN
+  // annotationInitializers RPAREN -> ^(
   // ANNOTATION_INIT_BLOCK[$LPAREN, \"ANNOTATION_INIT_BLOCK\"] annotationInitializers ) ;
   public final JavaParser.annotationInit_return annotationInit() throws RecognitionException {
     JavaParser.annotationInit_return retval = new JavaParser.annotationInit_return();
@@ -9936,9 +10377,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 62)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:682:5: ( LPAREN annotationInitializers RPAREN -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:682:5: ( LPAREN
+      // annotationInitializers RPAREN -> ^(
       // ANNOTATION_INIT_BLOCK[$LPAREN, \"ANNOTATION_INIT_BLOCK\"] annotationInitializers ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:682:9: LPAREN annotationInitializers RPAREN
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:682:9: LPAREN
+      // annotationInitializers RPAREN
       {
         LPAREN226 = (Token) match(input, LPAREN, FOLLOW_LPAREN_in_annotationInit8070);
         if (state.failed) return retval;
@@ -9969,9 +10412,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 683:9: -> ^( ANNOTATION_INIT_BLOCK[$LPAREN, \"ANNOTATION_INIT_BLOCK\"] annotationInitializers )
+          // 683:9: -> ^( ANNOTATION_INIT_BLOCK[$LPAREN, \"ANNOTATION_INIT_BLOCK\"]
+          // annotationInitializers )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:683:13: ^( ANNOTATION_INIT_BLOCK[$LPAREN,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:683:13: ^(
+            // ANNOTATION_INIT_BLOCK[$LPAREN,
             // \"ANNOTATION_INIT_BLOCK\"] annotationInitializers )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -10023,8 +10468,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationInitializers"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:686:1: annotationInitializers : ( annotationInitializer ( COMMA
-  // annotationInitializer )* -> ^( ANNOTATION_INIT_KEY_LIST ( annotationInitializer )+ ) | annotationElementValue -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:686:1: annotationInitializers : (
+  // annotationInitializer ( COMMA
+  // annotationInitializer )* -> ^( ANNOTATION_INIT_KEY_LIST ( annotationInitializer )+ ) |
+  // annotationElementValue -> ^(
   // ANNOTATION_INIT_DEFAULT_KEY annotationElementValue ) );
   public final JavaParser.annotationInitializers_return annotationInitializers()
       throws RecognitionException {
@@ -10051,8 +10498,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 63)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:687:5: ( annotationInitializer ( COMMA
-      // annotationInitializer )* -> ^( ANNOTATION_INIT_KEY_LIST ( annotationInitializer )+ ) | annotationElementValue -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:687:5: ( annotationInitializer (
+      // COMMA
+      // annotationInitializer )* -> ^( ANNOTATION_INIT_KEY_LIST ( annotationInitializer )+ ) |
+      // annotationElementValue -> ^(
       // ANNOTATION_INIT_DEFAULT_KEY annotationElementValue ) )
       int alt78 = 2;
       int LA78_0 = input.LA(1);
@@ -10124,7 +10573,8 @@ public class JavaParser extends Parser {
       }
       switch (alt78) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:687:9: annotationInitializer ( COMMA
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:687:9: annotationInitializer
+          // ( COMMA
           // annotationInitializer )*
           {
             pushFollow(FOLLOW_annotationInitializer_in_annotationInitializers8111);
@@ -10134,7 +10584,8 @@ public class JavaParser extends Parser {
             if (state.failed) return retval;
             if (state.backtracking == 0)
               stream_annotationInitializer.add(annotationInitializer229.getTree());
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:687:31: ( COMMA annotationInitializer )*
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:687:31: ( COMMA
+            // annotationInitializer )*
             loop77:
             do {
               int alt77 = 2;
@@ -10146,7 +10597,8 @@ public class JavaParser extends Parser {
 
               switch (alt77) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:687:32: COMMA annotationInitializer
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:687:32: COMMA
+                  // annotationInitializer
                   {
                     COMMA230 =
                         (Token) match(input, COMMA, FOLLOW_COMMA_in_annotationInitializers8114);
@@ -10184,7 +10636,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 688:9: -> ^( ANNOTATION_INIT_KEY_LIST ( annotationInitializer )+ )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:688:13: ^( ANNOTATION_INIT_KEY_LIST (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:688:13: ^(
+                // ANNOTATION_INIT_KEY_LIST (
                 // annotationInitializer )+ )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -10239,7 +10692,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 690:9: -> ^( ANNOTATION_INIT_DEFAULT_KEY annotationElementValue )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:690:13: ^( ANNOTATION_INIT_DEFAULT_KEY
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:690:13: ^(
+                // ANNOTATION_INIT_DEFAULT_KEY
                 // annotationElementValue )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -10292,7 +10746,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationInitializer"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:693:1: annotationInitializer : IDENT ASSIGN annotationElementValue ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:693:1: annotationInitializer : IDENT
+  // ASSIGN annotationElementValue ;
   public final JavaParser.annotationInitializer_return annotationInitializer()
       throws RecognitionException {
     JavaParser.annotationInitializer_return retval = new JavaParser.annotationInitializer_return();
@@ -10311,8 +10766,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 64)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:694:5: ( IDENT ASSIGN annotationElementValue )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:694:9: IDENT ASSIGN annotationElementValue
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:694:5: ( IDENT ASSIGN
+      // annotationElementValue )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:694:9: IDENT ASSIGN
+      // annotationElementValue
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -10362,7 +10819,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationElementValue"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:697:1: annotationElementValue : ( annotationElementValueExpression
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:697:1: annotationElementValue : (
+  // annotationElementValueExpression
   // | annotation | annotationElementValueArrayInitializer );
   public final JavaParser.annotationElementValue_return annotationElementValue()
       throws RecognitionException {
@@ -10383,7 +10841,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 65)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:698:5: ( annotationElementValueExpression | annotation |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:698:5: (
+      // annotationElementValueExpression | annotation |
       // annotationElementValueArrayInitializer )
       int alt79 = 3;
       switch (input.LA(1)) {
@@ -10443,7 +10902,8 @@ public class JavaParser extends Parser {
 
       switch (alt79) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:698:9: annotationElementValueExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:698:9:
+          // annotationElementValueExpression
           {
             root_0 = (CommonTree) adaptor.nil();
 
@@ -10470,7 +10930,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:700:9: annotationElementValueArrayInitializer
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:700:9:
+          // annotationElementValueArrayInitializer
           {
             root_0 = (CommonTree) adaptor.nil();
 
@@ -10514,7 +10975,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationElementValueExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:703:1: annotationElementValueExpression : conditionalExpression ->
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:703:1:
+  // annotationElementValueExpression : conditionalExpression ->
   // ^( EXPR conditionalExpression ) ;
   public final JavaParser.annotationElementValueExpression_return annotationElementValueExpression()
       throws RecognitionException {
@@ -10532,7 +10994,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 66)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:704:5: ( conditionalExpression -> ^( EXPR
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:704:5: ( conditionalExpression ->
+      // ^( EXPR
       // conditionalExpression ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:704:9: conditionalExpression
       {
@@ -10560,7 +11023,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 705:9: -> ^( EXPR conditionalExpression )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:705:13: ^( EXPR conditionalExpression )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:705:13: ^( EXPR
+            // conditionalExpression )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -10607,8 +11071,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationElementValueArrayInitializer"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:708:1: annotationElementValueArrayInitializer : LCURLY (
-  // annotationElementValue ( COMMA annotationElementValue )* )? ( COMMA )? RCURLY -> ^( ANNOTATION_INIT_ARRAY_ELEMENT[$LCURLY,
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:708:1:
+  // annotationElementValueArrayInitializer : LCURLY (
+  // annotationElementValue ( COMMA annotationElementValue )* )? ( COMMA )? RCURLY -> ^(
+  // ANNOTATION_INIT_ARRAY_ELEMENT[$LCURLY,
   // \"ANNOTATION_ELEM_VALUE_ARRAY_INIT\"] ( annotationElementValue )* ) ;
   public final JavaParser.annotationElementValueArrayInitializer_return
       annotationElementValueArrayInitializer() throws RecognitionException {
@@ -10639,10 +11105,12 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 67)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:5: ( LCURLY ( annotationElementValue ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:5: ( LCURLY (
+      // annotationElementValue ( COMMA
       // annotationElementValue )* )? ( COMMA )? RCURLY -> ^( ANNOTATION_INIT_ARRAY_ELEMENT[$LCURLY,
       // \"ANNOTATION_ELEM_VALUE_ARRAY_INIT\"] ( annotationElementValue )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:9: LCURLY ( annotationElementValue ( COMMA
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:9: LCURLY (
+      // annotationElementValue ( COMMA
       // annotationElementValue )* )? ( COMMA )? RCURLY
       {
         LCURLY240 =
@@ -10651,7 +11119,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_LCURLY.add(LCURLY240);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:16: ( annotationElementValue ( COMMA
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:16: (
+        // annotationElementValue ( COMMA
         // annotationElementValue )* )?
         int alt81 = 2;
         int LA81_0 = input.LA(1);
@@ -10683,7 +11152,8 @@ public class JavaParser extends Parser {
         }
         switch (alt81) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:17: annotationElementValue ( COMMA
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:17:
+            // annotationElementValue ( COMMA
             // annotationElementValue )*
             {
               pushFollow(
@@ -10694,7 +11164,8 @@ public class JavaParser extends Parser {
               if (state.failed) return retval;
               if (state.backtracking == 0)
                 stream_annotationElementValue.add(annotationElementValue241.getTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:40: ( COMMA annotationElementValue )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:40: ( COMMA
+              // annotationElementValue )*
               loop80:
               do {
                 int alt80 = 2;
@@ -10732,7 +11203,8 @@ public class JavaParser extends Parser {
 
                 switch (alt80) {
                   case 1:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:41: COMMA annotationElementValue
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:709:41: COMMA
+                    // annotationElementValue
                     {
                       COMMA242 =
                           (Token)
@@ -10803,11 +11275,13 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 710:9: -> ^( ANNOTATION_INIT_ARRAY_ELEMENT[$LCURLY, \"ANNOTATION_ELEM_VALUE_ARRAY_INIT\"] ( annotationElementValue
+          // 710:9: -> ^( ANNOTATION_INIT_ARRAY_ELEMENT[$LCURLY,
+          // \"ANNOTATION_ELEM_VALUE_ARRAY_INIT\"] ( annotationElementValue
           // )* )
           {
             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:710:13: ^(
-            // ANNOTATION_INIT_ARRAY_ELEMENT[$LCURLY, \"ANNOTATION_ELEM_VALUE_ARRAY_INIT\"] ( annotationElementValue )* )
+            // ANNOTATION_INIT_ARRAY_ELEMENT[$LCURLY, \"ANNOTATION_ELEM_VALUE_ARRAY_INIT\"] (
+            // annotationElementValue )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -10820,7 +11294,8 @@ public class JavaParser extends Parser {
                                   "ANNOTATION_ELEM_VALUE_ARRAY_INIT"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:710:90: ( annotationElementValue )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:710:90: (
+              // annotationElementValue )*
               while (stream_annotationElementValue.hasNext()) {
                 adaptor.addChild(root_1, stream_annotationElementValue.nextTree());
               }
@@ -10864,7 +11339,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationTypeDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:713:1: annotationTypeDeclaration[CommonTree modifiers] : AT
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:713:1:
+  // annotationTypeDeclaration[CommonTree modifiers] : AT
   // INTERFACE IDENT annotationBody -> ^( AT IDENT annotationBody ) ;
   public final JavaParser.annotationTypeDeclaration_return annotationTypeDeclaration(
       CommonTree modifiers) throws RecognitionException {
@@ -10892,9 +11368,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 68)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:714:5: ( AT INTERFACE IDENT annotationBody -> ^( AT IDENT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:714:5: ( AT INTERFACE IDENT
+      // annotationBody -> ^( AT IDENT
       // annotationBody ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:714:9: AT INTERFACE IDENT annotationBody
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:714:9: AT INTERFACE IDENT
+      // annotationBody
       {
         AT246 = (Token) match(input, AT, FOLLOW_AT_in_annotationTypeDeclaration8361);
         if (state.failed) return retval;
@@ -10932,7 +11410,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 715:9: -> ^( AT IDENT annotationBody )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:715:12: ^( AT IDENT annotationBody )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:715:12: ^( AT IDENT
+            // annotationBody )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 = (CommonTree) adaptor.becomeRoot(stream_AT.nextNode(), root_1);
@@ -10979,8 +11458,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationBody"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:718:1: annotationBody : LCURLY ( annotationScopeDeclarations )*
-  // RCURLY -> ^( ANNOTATION_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( annotationScopeDeclarations )* ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:718:1: annotationBody : LCURLY (
+  // annotationScopeDeclarations )*
+  // RCURLY -> ^( ANNOTATION_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] (
+  // annotationScopeDeclarations )* ) ;
   public final JavaParser.annotationBody_return annotationBody() throws RecognitionException {
     JavaParser.annotationBody_return retval = new JavaParser.annotationBody_return();
     retval.start = input.LT(1);
@@ -11001,15 +11482,19 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 69)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:719:5: ( LCURLY ( annotationScopeDeclarations )* RCURLY ->
-      // ^( ANNOTATION_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( annotationScopeDeclarations )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:719:9: LCURLY ( annotationScopeDeclarations )* RCURLY
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:719:5: ( LCURLY (
+      // annotationScopeDeclarations )* RCURLY ->
+      // ^( ANNOTATION_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] (
+      // annotationScopeDeclarations )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:719:9: LCURLY (
+      // annotationScopeDeclarations )* RCURLY
       {
         LCURLY250 = (Token) match(input, LCURLY, FOLLOW_LCURLY_in_annotationBody8410);
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_LCURLY.add(LCURLY250);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:719:16: ( annotationScopeDeclarations )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:719:16: (
+        // annotationScopeDeclarations )*
         loop83:
         do {
           int alt83 = 2;
@@ -11038,7 +11523,8 @@ public class JavaParser extends Parser {
 
           switch (alt83) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: annotationScopeDeclarations
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+              // annotationScopeDeclarations
               {
                 pushFollow(FOLLOW_annotationScopeDeclarations_in_annotationBody8412);
                 annotationScopeDeclarations251 = annotationScopeDeclarations();
@@ -11073,9 +11559,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 720:9: -> ^( ANNOTATION_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] ( annotationScopeDeclarations )* )
+          // 720:9: -> ^( ANNOTATION_TOP_LEVEL_SCOPE[$LCURLY, \"CLASS_TOP_LEVEL_SCOPE\"] (
+          // annotationScopeDeclarations )* )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:720:13: ^( ANNOTATION_TOP_LEVEL_SCOPE[$LCURLY,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:720:13: ^(
+            // ANNOTATION_TOP_LEVEL_SCOPE[$LCURLY,
             // \"CLASS_TOP_LEVEL_SCOPE\"] ( annotationScopeDeclarations )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -11087,7 +11575,8 @@ public class JavaParser extends Parser {
                                   ANNOTATION_TOP_LEVEL_SCOPE, LCURLY250, "CLASS_TOP_LEVEL_SCOPE"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:720:76: ( annotationScopeDeclarations )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:720:76: (
+              // annotationScopeDeclarations )*
               while (stream_annotationScopeDeclarations.hasNext()) {
                 adaptor.addChild(root_1, stream_annotationScopeDeclarations.nextTree());
               }
@@ -11131,9 +11620,12 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationScopeDeclarations"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:723:1: annotationScopeDeclarations : ( modifierList type ( IDENT
-  // LPAREN RPAREN ( annotationDefaultValue )? SEMI -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT ( annotationDefaultValue )? )
-  // | classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList ) ) | typeDeclaration );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:723:1: annotationScopeDeclarations :
+  // ( modifierList type ( IDENT
+  // LPAREN RPAREN ( annotationDefaultValue )? SEMI -> ^( ANNOTATION_METHOD_DECL modifierList type
+  // IDENT ( annotationDefaultValue )? )
+  // | classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type
+  // classFieldDeclaratorList ) ) | typeDeclaration );
   public final JavaParser.annotationScopeDeclarations_return annotationScopeDeclarations()
       throws RecognitionException {
     JavaParser.annotationScopeDeclarations_return retval =
@@ -11177,16 +11669,22 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 70)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:724:5: ( modifierList type ( IDENT LPAREN RPAREN (
-      // annotationDefaultValue )? SEMI -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT ( annotationDefaultValue )? ) |
-      // classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList ) ) | typeDeclaration )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:724:5: ( modifierList type (
+      // IDENT LPAREN RPAREN (
+      // annotationDefaultValue )? SEMI -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT (
+      // annotationDefaultValue )? ) |
+      // classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type
+      // classFieldDeclaratorList ) ) | typeDeclaration )
       int alt86 = 2;
       alt86 = dfa86.predict(input);
       switch (alt86) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:724:9: modifierList type ( IDENT LPAREN RPAREN (
-          // annotationDefaultValue )? SEMI -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT ( annotationDefaultValue )? )
-          // | classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList ) )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:724:9: modifierList type (
+          // IDENT LPAREN RPAREN (
+          // annotationDefaultValue )? SEMI -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT (
+          // annotationDefaultValue )? )
+          // | classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type
+          // classFieldDeclaratorList ) )
           {
             pushFollow(FOLLOW_modifierList_in_annotationScopeDeclarations8457);
             modifierList253 = modifierList();
@@ -11200,9 +11698,12 @@ public class JavaParser extends Parser {
             state._fsp--;
             if (state.failed) return retval;
             if (state.backtracking == 0) stream_type.add(type254.getTree());
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:9: ( IDENT LPAREN RPAREN (
-            // annotationDefaultValue )? SEMI -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT ( annotationDefaultValue )? )
-            // | classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList ) )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:9: ( IDENT LPAREN
+            // RPAREN (
+            // annotationDefaultValue )? SEMI -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT (
+            // annotationDefaultValue )? )
+            // | classFieldDeclaratorList SEMI -> ^( VAR_DECLARATION modifierList type
+            // classFieldDeclaratorList ) )
             int alt85 = 2;
             int LA85_0 = input.LA(1);
 
@@ -11236,7 +11737,8 @@ public class JavaParser extends Parser {
             }
             switch (alt85) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:13: IDENT LPAREN RPAREN (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:13: IDENT LPAREN
+                // RPAREN (
                 // annotationDefaultValue )? SEMI
                 {
                   IDENT255 =
@@ -11256,7 +11758,8 @@ public class JavaParser extends Parser {
                   if (state.failed) return retval;
                   if (state.backtracking == 0) stream_RPAREN.add(RPAREN257);
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:33: ( annotationDefaultValue )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:33: (
+                  // annotationDefaultValue )?
                   int alt84 = 2;
                   int LA84_0 = input.LA(1);
 
@@ -11265,7 +11768,8 @@ public class JavaParser extends Parser {
                   }
                   switch (alt84) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: annotationDefaultValue
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                      // annotationDefaultValue
                       {
                         pushFollow(
                             FOLLOW_annotationDefaultValue_in_annotationScopeDeclarations8479);
@@ -11298,9 +11802,11 @@ public class JavaParser extends Parser {
                             adaptor, "rule retval", retval != null ? retval.tree : null);
 
                     root_0 = (CommonTree) adaptor.nil();
-                    // 726:13: -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT ( annotationDefaultValue )? )
+                    // 726:13: -> ^( ANNOTATION_METHOD_DECL modifierList type IDENT (
+                    // annotationDefaultValue )? )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:726:17: ^( ANNOTATION_METHOD_DECL
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:726:17: ^(
+                      // ANNOTATION_METHOD_DECL
                       // modifierList type IDENT ( annotationDefaultValue )? )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -11331,7 +11837,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:727:13: classFieldDeclaratorList SEMI
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:727:13:
+                // classFieldDeclaratorList SEMI
                 {
                   pushFollow(FOLLOW_classFieldDeclaratorList_in_annotationScopeDeclarations8524);
                   classFieldDeclaratorList260 = classFieldDeclaratorList();
@@ -11361,7 +11868,8 @@ public class JavaParser extends Parser {
                     root_0 = (CommonTree) adaptor.nil();
                     // 728:13: -> ^( VAR_DECLARATION modifierList type classFieldDeclaratorList )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:728:17: ^( VAR_DECLARATION
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:728:17: ^(
+                      // VAR_DECLARATION
                       // modifierList type classFieldDeclaratorList )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -11430,7 +11938,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "annotationDefaultValue"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:733:1: annotationDefaultValue : DEFAULT annotationElementValue ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:733:1: annotationDefaultValue :
+  // DEFAULT annotationElementValue ;
   public final JavaParser.annotationDefaultValue_return annotationDefaultValue()
       throws RecognitionException {
     JavaParser.annotationDefaultValue_return retval =
@@ -11448,8 +11957,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 71)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:734:5: ( DEFAULT annotationElementValue )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:734:9: DEFAULT annotationElementValue
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:734:5: ( DEFAULT
+      // annotationElementValue )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:734:9: DEFAULT
+      // annotationElementValue
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -11497,7 +12008,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "block"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:739:1: block : LCURLY ( blockStatement )* RCURLY -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:739:1: block : LCURLY (
+  // blockStatement )* RCURLY -> ^(
   // BLOCK_SCOPE[$LCURLY, \"BLOCK_SCOPE\"] ( blockStatement )* ) ;
   public final JavaParser.block_return block() throws RecognitionException {
     JavaParser.block_return retval = new JavaParser.block_return();
@@ -11519,9 +12031,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 72)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:740:5: ( LCURLY ( blockStatement )* RCURLY -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:740:5: ( LCURLY ( blockStatement
+      // )* RCURLY -> ^(
       // BLOCK_SCOPE[$LCURLY, \"BLOCK_SCOPE\"] ( blockStatement )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:740:9: LCURLY ( blockStatement )* RCURLY
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:740:9: LCURLY ( blockStatement )*
+      // RCURLY
       {
         LCURLY265 = (Token) match(input, LCURLY, FOLLOW_LCURLY_in_block8618);
         if (state.failed) return retval;
@@ -11595,7 +12109,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 741:9: -> ^( BLOCK_SCOPE[$LCURLY, \"BLOCK_SCOPE\"] ( blockStatement )* )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:741:13: ^( BLOCK_SCOPE[$LCURLY,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:741:13: ^(
+            // BLOCK_SCOPE[$LCURLY,
             // \"BLOCK_SCOPE\"] ( blockStatement )* )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -11605,7 +12120,8 @@ public class JavaParser extends Parser {
                           (CommonTree) adaptor.create(BLOCK_SCOPE, LCURLY265, "BLOCK_SCOPE"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:741:51: ( blockStatement )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:741:51: ( blockStatement
+              // )*
               while (stream_blockStatement.hasNext()) {
                 adaptor.addChild(root_1, stream_blockStatement.nextTree());
               }
@@ -11649,7 +12165,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "blockStatement"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:744:1: blockStatement : ( localVariableDeclaration SEMI |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:744:1: blockStatement : (
+  // localVariableDeclaration SEMI |
   // typeDeclaration | statement );
   public final JavaParser.blockStatement_return blockStatement() throws RecognitionException {
     JavaParser.blockStatement_return retval = new JavaParser.blockStatement_return();
@@ -11670,13 +12187,15 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 73)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:745:5: ( localVariableDeclaration SEMI | typeDeclaration |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:745:5: ( localVariableDeclaration
+      // SEMI | typeDeclaration |
       // statement )
       int alt88 = 3;
       alt88 = dfa88.predict(input);
       switch (alt88) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:745:9: localVariableDeclaration SEMI
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:745:9:
+          // localVariableDeclaration SEMI
           {
             root_0 = (CommonTree) adaptor.nil();
 
@@ -11748,8 +12267,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "localVariableDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:750:1: localVariableDeclaration : localModifierList type
-  // classFieldDeclaratorList -> ^( VAR_DECLARATION localModifierList type classFieldDeclaratorList ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:750:1: localVariableDeclaration :
+  // localModifierList type
+  // classFieldDeclaratorList -> ^( VAR_DECLARATION localModifierList type classFieldDeclaratorList
+  // ) ;
   public final JavaParser.localVariableDeclaration_return localVariableDeclaration()
       throws RecognitionException {
     JavaParser.localVariableDeclaration_return retval =
@@ -11773,9 +12294,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 74)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:751:5: ( localModifierList type classFieldDeclaratorList
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:751:5: ( localModifierList type
+      // classFieldDeclaratorList
       // -> ^( VAR_DECLARATION localModifierList type classFieldDeclaratorList ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:751:9: localModifierList type classFieldDeclaratorList
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:751:9: localModifierList type
+      // classFieldDeclaratorList
       {
         pushFollow(FOLLOW_localModifierList_in_localVariableDeclaration8707);
         localModifierList272 = localModifierList();
@@ -11813,7 +12336,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 752:9: -> ^( VAR_DECLARATION localModifierList type classFieldDeclaratorList )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:752:13: ^( VAR_DECLARATION localModifierList
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:752:13: ^( VAR_DECLARATION
+            // localModifierList
             // type classFieldDeclaratorList )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -11864,17 +12388,28 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "statement"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:756:1: statement : ( block | ASSERT expr1= expression ( COLON
-  // expr2= expression SEMI -> ^( ASSERT $expr1 $expr2) | SEMI -> ^( ASSERT $expr1) ) | IF parenthesizedExpression ifStat= statement (
-  // ELSE elseStat= statement -> ^( IF parenthesizedExpression $ifStat $elseStat) | -> ^( IF parenthesizedExpression $ifStat) ) | FOR
-  // LPAREN ( forInit SEMI forCondition SEMI forUpdater RPAREN statement -> ^( FOR forInit forCondition forUpdater statement ) |
-  // localModifierList type IDENT COLON expression RPAREN statement -> ^( FOR_EACH[$FOR, \"FOR_EACH\"] localModifierList type IDENT
-  // expression statement ) ) | WHILE parenthesizedExpression statement -> ^( WHILE parenthesizedExpression statement ) | DO statement
-  // WHILE parenthesizedExpression SEMI -> ^( DO statement parenthesizedExpression ) | TRY block ( catches ( finallyClause )? |
-  // finallyClause ) -> ^( TRY block ( catches )? ( finallyClause )? ) | SWITCH parenthesizedExpression LCURLY switchBlockLabels RCURLY
-  // -> ^( SWITCH parenthesizedExpression switchBlockLabels ) | SYNCHRONIZED parenthesizedExpression block -> ^( SYNCHRONIZED
-  // parenthesizedExpression block ) | RETURN ( expression )? SEMI -> ^( RETURN ( expression )? ) | THROW expression SEMI -> ^( THROW
-  // expression ) | BREAK ( IDENT )? SEMI -> ^( BREAK ( IDENT )? ) | CONTINUE ( IDENT )? SEMI -> ^( CONTINUE ( IDENT )? ) | IDENT COLON
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:756:1: statement : ( block | ASSERT
+  // expr1= expression ( COLON
+  // expr2= expression SEMI -> ^( ASSERT $expr1 $expr2) | SEMI -> ^( ASSERT $expr1) ) | IF
+  // parenthesizedExpression ifStat= statement (
+  // ELSE elseStat= statement -> ^( IF parenthesizedExpression $ifStat $elseStat) | -> ^( IF
+  // parenthesizedExpression $ifStat) ) | FOR
+  // LPAREN ( forInit SEMI forCondition SEMI forUpdater RPAREN statement -> ^( FOR forInit
+  // forCondition forUpdater statement ) |
+  // localModifierList type IDENT COLON expression RPAREN statement -> ^( FOR_EACH[$FOR,
+  // \"FOR_EACH\"] localModifierList type IDENT
+  // expression statement ) ) | WHILE parenthesizedExpression statement -> ^( WHILE
+  // parenthesizedExpression statement ) | DO statement
+  // WHILE parenthesizedExpression SEMI -> ^( DO statement parenthesizedExpression ) | TRY block (
+  // catches ( finallyClause )? |
+  // finallyClause ) -> ^( TRY block ( catches )? ( finallyClause )? ) | SWITCH
+  // parenthesizedExpression LCURLY switchBlockLabels RCURLY
+  // -> ^( SWITCH parenthesizedExpression switchBlockLabels ) | SYNCHRONIZED parenthesizedExpression
+  // block -> ^( SYNCHRONIZED
+  // parenthesizedExpression block ) | RETURN ( expression )? SEMI -> ^( RETURN ( expression )? ) |
+  // THROW expression SEMI -> ^( THROW
+  // expression ) | BREAK ( IDENT )? SEMI -> ^( BREAK ( IDENT )? ) | CONTINUE ( IDENT )? SEMI -> ^(
+  // CONTINUE ( IDENT )? ) | IDENT COLON
   // statement -> ^( LABELED_STATEMENT IDENT statement ) | expression SEMI | SEMI );
   public final JavaParser.statement_return statement() throws RecognitionException {
     JavaParser.statement_return retval = new JavaParser.statement_return();
@@ -12061,18 +12596,30 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 75)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:757:5: ( block | ASSERT expr1= expression ( COLON expr2=
-      // expression SEMI -> ^( ASSERT $expr1 $expr2) | SEMI -> ^( ASSERT $expr1) ) | IF parenthesizedExpression ifStat= statement (
-      // ELSE elseStat= statement -> ^( IF parenthesizedExpression $ifStat $elseStat) | -> ^( IF parenthesizedExpression $ifStat) )
-      // | FOR LPAREN ( forInit SEMI forCondition SEMI forUpdater RPAREN statement -> ^( FOR forInit forCondition forUpdater
-      // statement ) | localModifierList type IDENT COLON expression RPAREN statement -> ^( FOR_EACH[$FOR,
-      // \"FOR_EACH\"] localModifierList type IDENT expression statement ) ) | WHILE parenthesizedExpression statement -> ^( WHILE
-      // parenthesizedExpression statement ) | DO statement WHILE parenthesizedExpression SEMI -> ^( DO statement
-      // parenthesizedExpression ) | TRY block ( catches ( finallyClause )? | finallyClause ) -> ^( TRY block ( catches )? (
-      // finallyClause )? ) | SWITCH parenthesizedExpression LCURLY switchBlockLabels RCURLY -> ^( SWITCH parenthesizedExpression
-      // switchBlockLabels ) | SYNCHRONIZED parenthesizedExpression block -> ^( SYNCHRONIZED parenthesizedExpression block ) |
-      // RETURN ( expression )? SEMI -> ^( RETURN ( expression )? ) | THROW expression SEMI -> ^( THROW expression ) | BREAK (
-      // IDENT )? SEMI -> ^( BREAK ( IDENT )? ) | CONTINUE ( IDENT )? SEMI -> ^( CONTINUE ( IDENT )? ) | IDENT COLON statement -> ^
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:757:5: ( block | ASSERT expr1=
+      // expression ( COLON expr2=
+      // expression SEMI -> ^( ASSERT $expr1 $expr2) | SEMI -> ^( ASSERT $expr1) ) | IF
+      // parenthesizedExpression ifStat= statement (
+      // ELSE elseStat= statement -> ^( IF parenthesizedExpression $ifStat $elseStat) | -> ^( IF
+      // parenthesizedExpression $ifStat) )
+      // | FOR LPAREN ( forInit SEMI forCondition SEMI forUpdater RPAREN statement -> ^( FOR forInit
+      // forCondition forUpdater
+      // statement ) | localModifierList type IDENT COLON expression RPAREN statement -> ^(
+      // FOR_EACH[$FOR,
+      // \"FOR_EACH\"] localModifierList type IDENT expression statement ) ) | WHILE
+      // parenthesizedExpression statement -> ^( WHILE
+      // parenthesizedExpression statement ) | DO statement WHILE parenthesizedExpression SEMI -> ^(
+      // DO statement
+      // parenthesizedExpression ) | TRY block ( catches ( finallyClause )? | finallyClause ) -> ^(
+      // TRY block ( catches )? (
+      // finallyClause )? ) | SWITCH parenthesizedExpression LCURLY switchBlockLabels RCURLY -> ^(
+      // SWITCH parenthesizedExpression
+      // switchBlockLabels ) | SYNCHRONIZED parenthesizedExpression block -> ^( SYNCHRONIZED
+      // parenthesizedExpression block ) |
+      // RETURN ( expression )? SEMI -> ^( RETURN ( expression )? ) | THROW expression SEMI -> ^(
+      // THROW expression ) | BREAK (
+      // IDENT )? SEMI -> ^( BREAK ( IDENT )? ) | CONTINUE ( IDENT )? SEMI -> ^( CONTINUE ( IDENT )?
+      // ) | IDENT COLON statement -> ^
       // ( LABELED_STATEMENT IDENT statement ) | expression SEMI | SEMI )
       int alt97 = 16;
       alt97 = dfa97.predict(input);
@@ -12091,7 +12638,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:758:9: ASSERT expr1= expression ( COLON expr2=
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:758:9: ASSERT expr1=
+          // expression ( COLON expr2=
           // expression SEMI -> ^( ASSERT $expr1 $expr2) | SEMI -> ^( ASSERT $expr1) )
           {
             ASSERT276 = (Token) match(input, ASSERT, FOLLOW_ASSERT_in_statement8774);
@@ -12104,7 +12652,8 @@ public class JavaParser extends Parser {
             state._fsp--;
             if (state.failed) return retval;
             if (state.backtracking == 0) stream_expression.add(expr1.getTree());
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:759:9: ( COLON expr2= expression SEMI -> ^( ASSERT
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:759:9: ( COLON expr2=
+            // expression SEMI -> ^( ASSERT
             // $expr1 $expr2) | SEMI -> ^( ASSERT $expr1) )
             int alt89 = 2;
             int LA89_0 = input.LA(1);
@@ -12124,7 +12673,8 @@ public class JavaParser extends Parser {
             }
             switch (alt89) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:759:13: COLON expr2= expression SEMI
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:759:13: COLON expr2=
+                // expression SEMI
                 {
                   COLON277 = (Token) match(input, COLON, FOLLOW_COLON_in_statement8793);
                   if (state.failed) return retval;
@@ -12162,7 +12712,8 @@ public class JavaParser extends Parser {
                     root_0 = (CommonTree) adaptor.nil();
                     // 759:77: -> ^( ASSERT $expr1 $expr2)
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:759:81: ^( ASSERT $expr1 $expr2)
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:759:81: ^( ASSERT
+                      // $expr1 $expr2)
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
                         root_1 = (CommonTree) adaptor.becomeRoot(stream_ASSERT.nextNode(), root_1);
@@ -12204,7 +12755,8 @@ public class JavaParser extends Parser {
                     root_0 = (CommonTree) adaptor.nil();
                     // 760:77: -> ^( ASSERT $expr1)
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:760:81: ^( ASSERT $expr1)
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:760:81: ^( ASSERT
+                      // $expr1)
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
                         root_1 = (CommonTree) adaptor.becomeRoot(stream_ASSERT.nextNode(), root_1);
@@ -12223,8 +12775,10 @@ public class JavaParser extends Parser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:762:9: IF parenthesizedExpression ifStat=
-          // statement ( ELSE elseStat= statement -> ^( IF parenthesizedExpression $ifStat $elseStat) | -> ^( IF
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:762:9: IF
+          // parenthesizedExpression ifStat=
+          // statement ( ELSE elseStat= statement -> ^( IF parenthesizedExpression $ifStat
+          // $elseStat) | -> ^( IF
           // parenthesizedExpression $ifStat) )
           {
             IF280 = (Token) match(input, IF, FOLLOW_IF_in_statement8951);
@@ -12244,8 +12798,10 @@ public class JavaParser extends Parser {
             state._fsp--;
             if (state.failed) return retval;
             if (state.backtracking == 0) stream_statement.add(ifStat.getTree());
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:763:9: ( ELSE elseStat= statement -> ^( IF
-            // parenthesizedExpression $ifStat $elseStat) | -> ^( IF parenthesizedExpression $ifStat) )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:763:9: ( ELSE elseStat=
+            // statement -> ^( IF
+            // parenthesizedExpression $ifStat $elseStat) | -> ^( IF parenthesizedExpression
+            // $ifStat) )
             int alt90 = 2;
             int LA90_0 = input.LA(1);
 
@@ -12299,7 +12855,8 @@ public class JavaParser extends Parser {
             }
             switch (alt90) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:763:13: ELSE elseStat= statement
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:763:13: ELSE elseStat=
+                // statement
                 {
                   ELSE282 = (Token) match(input, ELSE, FOLLOW_ELSE_in_statement8972);
                   if (state.failed) return retval;
@@ -12396,9 +12953,12 @@ public class JavaParser extends Parser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:766:9: FOR LPAREN ( forInit SEMI forCondition SEMI
-          // forUpdater RPAREN statement -> ^( FOR forInit forCondition forUpdater statement ) | localModifierList type IDENT
-          // COLON expression RPAREN statement -> ^( FOR_EACH[$FOR, \"FOR_EACH\"] localModifierList type IDENT expression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:766:9: FOR LPAREN ( forInit
+          // SEMI forCondition SEMI
+          // forUpdater RPAREN statement -> ^( FOR forInit forCondition forUpdater statement ) |
+          // localModifierList type IDENT
+          // COLON expression RPAREN statement -> ^( FOR_EACH[$FOR, \"FOR_EACH\"] localModifierList
+          // type IDENT expression
           // statement ) )
           {
             FOR283 = (Token) match(input, FOR, FOLLOW_FOR_in_statement9142);
@@ -12409,14 +12969,18 @@ public class JavaParser extends Parser {
             if (state.failed) return retval;
             if (state.backtracking == 0) stream_LPAREN.add(LPAREN284);
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:9: ( forInit SEMI forCondition SEMI forUpdater
-            // RPAREN statement -> ^( FOR forInit forCondition forUpdater statement ) | localModifierList type IDENT COLON
-            // expression RPAREN statement -> ^( FOR_EACH[$FOR, \"FOR_EACH\"] localModifierList type IDENT expression statement ) )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:9: ( forInit SEMI
+            // forCondition SEMI forUpdater
+            // RPAREN statement -> ^( FOR forInit forCondition forUpdater statement ) |
+            // localModifierList type IDENT COLON
+            // expression RPAREN statement -> ^( FOR_EACH[$FOR, \"FOR_EACH\"] localModifierList type
+            // IDENT expression statement ) )
             int alt91 = 2;
             alt91 = dfa91.predict(input);
             switch (alt91) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:13: forInit SEMI forCondition SEMI
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:13: forInit SEMI
+                // forCondition SEMI
                 // forUpdater RPAREN statement
                 {
                   pushFollow(FOLLOW_forInit_in_statement9159);
@@ -12472,7 +13036,8 @@ public class JavaParser extends Parser {
                     root_0 = (CommonTree) adaptor.nil();
                     // 767:77: -> ^( FOR forInit forCondition forUpdater statement )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:81: ^( FOR forInit
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:81: ^( FOR
+                      // forInit
                       // forCondition forUpdater statement )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -12492,7 +13057,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:768:13: localModifierList type IDENT COLON
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:768:13:
+                // localModifierList type IDENT COLON
                 // expression RPAREN statement
                 {
                   pushFollow(FOLLOW_localModifierList_in_statement9206);
@@ -12547,9 +13113,11 @@ public class JavaParser extends Parser {
                             adaptor, "rule retval", retval != null ? retval.tree : null);
 
                     root_0 = (CommonTree) adaptor.nil();
-                    // 769:77: -> ^( FOR_EACH[$FOR, \"FOR_EACH\"] localModifierList type IDENT expression statement )
+                    // 769:77: -> ^( FOR_EACH[$FOR, \"FOR_EACH\"] localModifierList type IDENT
+                    // expression statement )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:769:81: ^( FOR_EACH[$FOR,
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:769:81: ^(
+                      // FOR_EACH[$FOR,
                       // \"FOR_EACH\"] localModifierList type IDENT expression statement )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -12577,7 +13145,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 5:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:771:9: WHILE parenthesizedExpression statement
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:771:9: WHILE
+          // parenthesizedExpression statement
           {
             WHILE299 = (Token) match(input, WHILE, FOLLOW_WHILE_in_statement9333);
             if (state.failed) return retval;
@@ -12613,7 +13182,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 771:77: -> ^( WHILE parenthesizedExpression statement )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:771:81: ^( WHILE parenthesizedExpression
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:771:81: ^( WHILE
+                // parenthesizedExpression
                 // statement )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -12631,7 +13201,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 6:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:772:9: DO statement WHILE parenthesizedExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:772:9: DO statement WHILE
+          // parenthesizedExpression
           // SEMI
           {
             DO302 = (Token) match(input, DO, FOLLOW_DO_in_statement9386);
@@ -12693,7 +13264,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 7:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:9: TRY block ( catches ( finallyClause )? |
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:9: TRY block ( catches (
+          // finallyClause )? |
           // finallyClause )
           {
             TRY307 = (Token) match(input, TRY, FOLLOW_TRY_in_statement9435);
@@ -12706,7 +13278,8 @@ public class JavaParser extends Parser {
             state._fsp--;
             if (state.failed) return retval;
             if (state.backtracking == 0) stream_block.add(block308.getTree());
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:19: ( catches ( finallyClause )? |
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:19: ( catches (
+            // finallyClause )? |
             // finallyClause )
             int alt93 = 2;
             int LA93_0 = input.LA(1);
@@ -12726,7 +13299,8 @@ public class JavaParser extends Parser {
             }
             switch (alt93) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:20: catches ( finallyClause )?
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:20: catches (
+                // finallyClause )?
                 {
                   pushFollow(FOLLOW_catches_in_statement9440);
                   catches309 = catches();
@@ -12734,7 +13308,8 @@ public class JavaParser extends Parser {
                   state._fsp--;
                   if (state.failed) return retval;
                   if (state.backtracking == 0) stream_catches.add(catches309.getTree());
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:28: ( finallyClause )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:28: (
+                  // finallyClause )?
                   int alt92 = 2;
                   int LA92_0 = input.LA(1);
 
@@ -12743,7 +13318,8 @@ public class JavaParser extends Parser {
                   }
                   switch (alt92) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: finallyClause
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                      // finallyClause
                       {
                         pushFollow(FOLLOW_finallyClause_in_statement9442);
                         finallyClause310 = finallyClause();
@@ -12786,7 +13362,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 773:77: -> ^( TRY block ( catches )? ( finallyClause )? )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:81: ^( TRY block ( catches )? (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:81: ^( TRY block (
+                // catches )? (
                 // finallyClause )? )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -12798,7 +13375,8 @@ public class JavaParser extends Parser {
                     adaptor.addChild(root_1, stream_catches.nextTree());
                   }
                   stream_catches.reset();
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:102: ( finallyClause )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:773:102: (
+                  // finallyClause )?
                   if (stream_finallyClause.hasNext()) {
                     adaptor.addChild(root_1, stream_finallyClause.nextTree());
                   }
@@ -12813,7 +13391,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 8:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:774:9: SWITCH parenthesizedExpression LCURLY
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:774:9: SWITCH
+          // parenthesizedExpression LCURLY
           // switchBlockLabels RCURLY
           {
             SWITCH312 = (Token) match(input, SWITCH, FOLLOW_SWITCH_in_statement9490);
@@ -12858,7 +13437,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 774:77: -> ^( SWITCH parenthesizedExpression switchBlockLabels )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:774:81: ^( SWITCH parenthesizedExpression
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:774:81: ^( SWITCH
+                // parenthesizedExpression
                 // switchBlockLabels )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -12876,7 +13456,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 9:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:775:9: SYNCHRONIZED parenthesizedExpression block
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:775:9: SYNCHRONIZED
+          // parenthesizedExpression block
           {
             SYNCHRONIZED317 =
                 (Token) match(input, SYNCHRONIZED, FOLLOW_SYNCHRONIZED_in_statement9524);
@@ -12931,7 +13512,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 10:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:776:9: RETURN ( expression )? SEMI
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:776:9: RETURN ( expression )?
+          // SEMI
           {
             RETURN320 = (Token) match(input, RETURN, FOLLOW_RETURN_in_statement9574);
             if (state.failed) return retval;
@@ -12998,12 +13580,14 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 776:77: -> ^( RETURN ( expression )? )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:776:81: ^( RETURN ( expression )? )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:776:81: ^( RETURN (
+                // expression )? )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_RETURN.nextNode(), root_1);
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:776:90: ( expression )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:776:90: ( expression
+                  // )?
                   if (stream_expression.hasNext()) {
                     adaptor.addChild(root_1, stream_expression.nextTree());
                   }
@@ -13050,7 +13634,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 777:77: -> ^( THROW expression )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:777:81: ^( THROW expression )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:777:81: ^( THROW
+                // expression )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_THROW.nextNode(), root_1);
@@ -13110,7 +13695,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 778:77: -> ^( BREAK ( IDENT )? )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:778:81: ^( BREAK ( IDENT )? )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:778:81: ^( BREAK (
+                // IDENT )? )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_BREAK.nextNode(), root_1);
@@ -13130,7 +13716,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 13:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:779:9: CONTINUE ( IDENT )? SEMI
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:779:9: CONTINUE ( IDENT )?
+          // SEMI
           {
             CONTINUE329 = (Token) match(input, CONTINUE, FOLLOW_CONTINUE_in_statement9787);
             if (state.failed) return retval;
@@ -13174,7 +13761,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 779:77: -> ^( CONTINUE ( IDENT )? )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:779:81: ^( CONTINUE ( IDENT )? )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:779:81: ^( CONTINUE (
+                // IDENT )? )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_CONTINUE.nextNode(), root_1);
@@ -13227,7 +13815,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 780:77: -> ^( LABELED_STATEMENT IDENT statement )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:780:81: ^( LABELED_STATEMENT IDENT
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:780:81: ^(
+                // LABELED_STATEMENT IDENT
                 // statement )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -13307,7 +13896,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "catches"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:785:1: catches : ( catchClause )+ -> ^( CATCH_CLAUSE_LIST (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:785:1: catches : ( catchClause )+ ->
+  // ^( CATCH_CLAUSE_LIST (
   // catchClause )+ ) ;
   public final JavaParser.catches_return catches() throws RecognitionException {
     JavaParser.catches_return retval = new JavaParser.catches_return();
@@ -13323,7 +13913,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 76)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:786:5: ( ( catchClause )+ -> ^( CATCH_CLAUSE_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:786:5: ( ( catchClause )+ -> ^(
+      // CATCH_CLAUSE_LIST (
       // catchClause )+ ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:786:9: ( catchClause )+
       {
@@ -13379,7 +13970,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 787:9: -> ^( CATCH_CLAUSE_LIST ( catchClause )+ )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:787:13: ^( CATCH_CLAUSE_LIST ( catchClause )+ )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:787:13: ^(
+            // CATCH_CLAUSE_LIST ( catchClause )+ )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -13434,7 +14026,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "catchClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:790:1: catchClause : CATCH LPAREN formalParameterStandardDecl
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:790:1: catchClause : CATCH LPAREN
+  // formalParameterStandardDecl
   // RPAREN block ;
   public final JavaParser.catchClause_return catchClause() throws RecognitionException {
     JavaParser.catchClause_return retval = new JavaParser.catchClause_return();
@@ -13457,9 +14050,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 77)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:791:5: ( CATCH LPAREN formalParameterStandardDecl RPAREN
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:791:5: ( CATCH LPAREN
+      // formalParameterStandardDecl RPAREN
       // block )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:791:9: CATCH LPAREN formalParameterStandardDecl RPAREN block
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:791:9: CATCH LPAREN
+      // formalParameterStandardDecl RPAREN block
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -13518,7 +14113,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "finallyClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:794:1: finallyClause : FINALLY block -> block ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:794:1: finallyClause : FINALLY block
+  // -> block ;
   public final JavaParser.finallyClause_return finallyClause() throws RecognitionException {
     JavaParser.finallyClause_return retval = new JavaParser.finallyClause_return();
     retval.start = input.LT(1);
@@ -13602,8 +14198,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "switchBlockLabels"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:799:1: switchBlockLabels : switchCaseLabels ( switchDefaultLabel )
-  // ? switchCaseLabels -> ^( SWITCH_BLOCK_LABEL_LIST switchCaseLabels ( switchDefaultLabel )? switchCaseLabels ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:799:1: switchBlockLabels :
+  // switchCaseLabels ( switchDefaultLabel )
+  // ? switchCaseLabels -> ^( SWITCH_BLOCK_LABEL_LIST switchCaseLabels ( switchDefaultLabel )?
+  // switchCaseLabels ) ;
   public final JavaParser.switchBlockLabels_return switchBlockLabels() throws RecognitionException {
     JavaParser.switchBlockLabels_return retval = new JavaParser.switchBlockLabels_return();
     retval.start = input.LT(1);
@@ -13624,9 +14222,12 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 79)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:800:5: ( switchCaseLabels ( switchDefaultLabel )?
-      // switchCaseLabels -> ^( SWITCH_BLOCK_LABEL_LIST switchCaseLabels ( switchDefaultLabel )? switchCaseLabels ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:800:9: switchCaseLabels ( switchDefaultLabel )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:800:5: ( switchCaseLabels (
+      // switchDefaultLabel )?
+      // switchCaseLabels -> ^( SWITCH_BLOCK_LABEL_LIST switchCaseLabels ( switchDefaultLabel )?
+      // switchCaseLabels ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:800:9: switchCaseLabels (
+      // switchDefaultLabel )?
       // switchCaseLabels
       {
         pushFollow(FOLLOW_switchCaseLabels_in_switchBlockLabels10088);
@@ -13678,9 +14279,11 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 801:9: -> ^( SWITCH_BLOCK_LABEL_LIST switchCaseLabels ( switchDefaultLabel )? switchCaseLabels )
+          // 801:9: -> ^( SWITCH_BLOCK_LABEL_LIST switchCaseLabels ( switchDefaultLabel )?
+          // switchCaseLabels )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:801:13: ^( SWITCH_BLOCK_LABEL_LIST
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:801:13: ^(
+            // SWITCH_BLOCK_LABEL_LIST
             // switchCaseLabels ( switchDefaultLabel )? switchCaseLabels )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -13692,7 +14295,8 @@ public class JavaParser extends Parser {
                           root_1);
 
               adaptor.addChild(root_1, stream_switchCaseLabels.nextTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:801:56: ( switchDefaultLabel )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:801:56: (
+              // switchDefaultLabel )?
               if (stream_switchDefaultLabel.hasNext()) {
                 adaptor.addChild(root_1, stream_switchDefaultLabel.nextTree());
               }
@@ -13737,7 +14341,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "switchCaseLabels"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:804:1: switchCaseLabels : ( switchCaseLabel )* ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:804:1: switchCaseLabels : (
+  // switchCaseLabel )* ;
   public final JavaParser.switchCaseLabels_return switchCaseLabels() throws RecognitionException {
     JavaParser.switchCaseLabels_return retval = new JavaParser.switchCaseLabels_return();
     retval.start = input.LT(1);
@@ -13818,7 +14423,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "switchCaseLabel"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:808:1: switchCaseLabel : CASE expression COLON ( blockStatement )* ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:808:1: switchCaseLabel : CASE
+  // expression COLON ( blockStatement )* ;
   public final JavaParser.switchCaseLabel_return switchCaseLabel() throws RecognitionException {
     JavaParser.switchCaseLabel_return retval = new JavaParser.switchCaseLabel_return();
     retval.start = input.LT(1);
@@ -13838,8 +14444,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 81)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:809:5: ( CASE expression COLON ( blockStatement )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:809:9: CASE expression COLON ( blockStatement )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:809:5: ( CASE expression COLON (
+      // blockStatement )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:809:9: CASE expression COLON (
+      // blockStatement )*
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -13936,7 +14544,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "switchDefaultLabel"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:812:1: switchDefaultLabel : DEFAULT COLON ( blockStatement )* ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:812:1: switchDefaultLabel : DEFAULT
+  // COLON ( blockStatement )* ;
   public final JavaParser.switchDefaultLabel_return switchDefaultLabel()
       throws RecognitionException {
     JavaParser.switchDefaultLabel_return retval = new JavaParser.switchDefaultLabel_return();
@@ -13955,8 +14564,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 82)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:813:5: ( DEFAULT COLON ( blockStatement )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:813:9: DEFAULT COLON ( blockStatement )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:813:5: ( DEFAULT COLON (
+      // blockStatement )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:813:9: DEFAULT COLON (
+      // blockStatement )*
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -14047,8 +14658,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "forInit"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:816:1: forInit : ( localVariableDeclaration -> ^( FOR_INIT
-  // localVariableDeclaration ) | expressionList -> ^( FOR_INIT expressionList ) | -> ^( FOR_INIT ) );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:816:1: forInit : (
+  // localVariableDeclaration -> ^( FOR_INIT
+  // localVariableDeclaration ) | expressionList -> ^( FOR_INIT expressionList ) | -> ^( FOR_INIT )
+  // );
   public final JavaParser.forInit_return forInit() throws RecognitionException {
     JavaParser.forInit_return retval = new JavaParser.forInit_return();
     retval.start = input.LT(1);
@@ -14067,13 +14680,16 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 83)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:817:5: ( localVariableDeclaration -> ^( FOR_INIT
-      // localVariableDeclaration ) | expressionList -> ^( FOR_INIT expressionList ) | -> ^( FOR_INIT ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:817:5: ( localVariableDeclaration
+      // -> ^( FOR_INIT
+      // localVariableDeclaration ) | expressionList -> ^( FOR_INIT expressionList ) | -> ^(
+      // FOR_INIT ) )
       int alt103 = 3;
       alt103 = dfa103.predict(input);
       switch (alt103) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:817:9: localVariableDeclaration
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:817:9:
+          // localVariableDeclaration
           {
             pushFollow(FOLLOW_localVariableDeclaration_in_forInit10228);
             localVariableDeclaration357 = localVariableDeclaration();
@@ -14144,7 +14760,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 818:37: -> ^( FOR_INIT expressionList )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:818:41: ^( FOR_INIT expressionList )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:818:41: ^( FOR_INIT
+                // expressionList )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 =
@@ -14229,7 +14846,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "forCondition"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:822:1: forCondition : ( expression )? -> ^( FOR_CONDITION (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:822:1: forCondition : ( expression )?
+  // -> ^( FOR_CONDITION (
   // expression )? ) ;
   public final JavaParser.forCondition_return forCondition() throws RecognitionException {
     JavaParser.forCondition_return retval = new JavaParser.forCondition_return();
@@ -14245,7 +14863,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 84)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:823:5: ( ( expression )? -> ^( FOR_CONDITION ( expression
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:823:5: ( ( expression )? -> ^(
+      // FOR_CONDITION ( expression
       // )? ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:823:9: ( expression )?
       {
@@ -14306,7 +14925,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 824:9: -> ^( FOR_CONDITION ( expression )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:824:13: ^( FOR_CONDITION ( expression )? )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:824:13: ^( FOR_CONDITION (
+            // expression )? )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -14358,7 +14978,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "forUpdater"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:827:1: forUpdater : ( expressionList )? -> ^( FOR_UPDATE (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:827:1: forUpdater : ( expressionList
+  // )? -> ^( FOR_UPDATE (
   // expressionList )? ) ;
   public final JavaParser.forUpdater_return forUpdater() throws RecognitionException {
     JavaParser.forUpdater_return retval = new JavaParser.forUpdater_return();
@@ -14374,7 +14995,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 85)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:828:5: ( ( expressionList )? -> ^( FOR_UPDATE (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:828:5: ( ( expressionList )? ->
+      // ^( FOR_UPDATE (
       // expressionList )? ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:828:9: ( expressionList )?
       {
@@ -14435,7 +15057,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 829:9: -> ^( FOR_UPDATE ( expressionList )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:829:13: ^( FOR_UPDATE ( expressionList )? )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:829:13: ^( FOR_UPDATE (
+            // expressionList )? )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -14443,7 +15066,8 @@ public class JavaParser extends Parser {
                       adaptor.becomeRoot(
                           (CommonTree) adaptor.create(FOR_UPDATE, "FOR_UPDATE"), root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:829:26: ( expressionList )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:829:26: ( expressionList
+              // )?
               if (stream_expressionList.hasNext()) {
                 adaptor.addChild(root_1, stream_expressionList.nextTree());
               }
@@ -14487,7 +15111,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "parenthesizedExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:834:1: parenthesizedExpression : LPAREN expression RPAREN -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:834:1: parenthesizedExpression :
+  // LPAREN expression RPAREN -> ^(
   // PARENTESIZED_EXPR[$LPAREN, \"PARENTESIZED_EXPR\"] expression ) ;
   public final JavaParser.parenthesizedExpression_return parenthesizedExpression()
       throws RecognitionException {
@@ -14511,7 +15136,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 86)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:835:5: ( LPAREN expression RPAREN -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:835:5: ( LPAREN expression RPAREN
+      // -> ^(
       // PARENTESIZED_EXPR[$LPAREN, \"PARENTESIZED_EXPR\"] expression ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:835:9: LPAREN expression RPAREN
       {
@@ -14545,7 +15171,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 836:9: -> ^( PARENTESIZED_EXPR[$LPAREN, \"PARENTESIZED_EXPR\"] expression )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:836:13: ^( PARENTESIZED_EXPR[$LPAREN,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:836:13: ^(
+            // PARENTESIZED_EXPR[$LPAREN,
             // \"PARENTESIZED_EXPR\"] expression )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -14596,7 +15223,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "expressionList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:839:1: expressionList : expression ( COMMA expression )* ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:839:1: expressionList : expression (
+  // COMMA expression )* ;
   public final JavaParser.expressionList_return expressionList() throws RecognitionException {
     JavaParser.expressionList_return retval = new JavaParser.expressionList_return();
     retval.start = input.LT(1);
@@ -14614,8 +15242,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 87)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:840:5: ( expression ( COMMA expression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:840:9: expression ( COMMA expression )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:840:5: ( expression ( COMMA
+      // expression )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:840:9: expression ( COMMA
+      // expression )*
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -14686,7 +15316,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "expression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:843:1: expression : assignmentExpression -> ^( EXPR
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:843:1: expression :
+  // assignmentExpression -> ^( EXPR
   // assignmentExpression ) ;
   public final JavaParser.expression_return expression() throws RecognitionException {
     JavaParser.expression_return retval = new JavaParser.expression_return();
@@ -14702,7 +15333,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 88)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:844:5: ( assignmentExpression -> ^( EXPR
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:844:5: ( assignmentExpression ->
+      // ^( EXPR
       // assignmentExpression ) )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:844:9: assignmentExpression
       {
@@ -14730,7 +15362,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 845:9: -> ^( EXPR assignmentExpression )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:845:13: ^( EXPR assignmentExpression )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:845:13: ^( EXPR
+            // assignmentExpression )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -14777,8 +15410,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "assignmentExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:848:1: assignmentExpression : conditionalExpression ( ( ASSIGN |
-  // PLUS_ASSIGN | MINUS_ASSIGN | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN | SHIFT_LEFT_ASSIGN |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:848:1: assignmentExpression :
+  // conditionalExpression ( ( ASSIGN |
+  // PLUS_ASSIGN | MINUS_ASSIGN | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN |
+  // MOD_ASSIGN | SHIFT_LEFT_ASSIGN |
   // SHIFT_RIGHT_ASSIGN | BIT_SHIFT_RIGHT_ASSIGN ) assignmentExpression )? ;
   public final JavaParser.assignmentExpression_return assignmentExpression()
       throws RecognitionException {
@@ -14820,11 +15455,15 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 89)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:849:5: ( conditionalExpression ( ( ASSIGN | PLUS_ASSIGN |
-      // MINUS_ASSIGN | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN | SHIFT_LEFT_ASSIGN |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:849:5: ( conditionalExpression (
+      // ( ASSIGN | PLUS_ASSIGN |
+      // MINUS_ASSIGN | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN
+      // | SHIFT_LEFT_ASSIGN |
       // SHIFT_RIGHT_ASSIGN | BIT_SHIFT_RIGHT_ASSIGN ) assignmentExpression )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:849:9: conditionalExpression ( ( ASSIGN | PLUS_ASSIGN |
-      // MINUS_ASSIGN | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN | SHIFT_LEFT_ASSIGN |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:849:9: conditionalExpression ( (
+      // ASSIGN | PLUS_ASSIGN |
+      // MINUS_ASSIGN | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN
+      // | SHIFT_LEFT_ASSIGN |
       // SHIFT_RIGHT_ASSIGN | BIT_SHIFT_RIGHT_ASSIGN ) assignmentExpression )?
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -14835,8 +15474,10 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, conditionalExpression368.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:850:9: ( ( ASSIGN | PLUS_ASSIGN | MINUS_ASSIGN |
-        // STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN | SHIFT_LEFT_ASSIGN | SHIFT_RIGHT_ASSIGN |
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:850:9: ( ( ASSIGN | PLUS_ASSIGN
+        // | MINUS_ASSIGN |
+        // STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN |
+        // SHIFT_LEFT_ASSIGN | SHIFT_RIGHT_ASSIGN |
         // BIT_SHIFT_RIGHT_ASSIGN ) assignmentExpression )?
         int alt108 = 2;
         int LA108_0 = input.LA(1);
@@ -14856,12 +15497,16 @@ public class JavaParser extends Parser {
         }
         switch (alt108) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:850:13: ( ASSIGN | PLUS_ASSIGN | MINUS_ASSIGN
-            // | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN | SHIFT_LEFT_ASSIGN |
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:850:13: ( ASSIGN |
+            // PLUS_ASSIGN | MINUS_ASSIGN
+            // | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN |
+            // SHIFT_LEFT_ASSIGN |
             // SHIFT_RIGHT_ASSIGN | BIT_SHIFT_RIGHT_ASSIGN ) assignmentExpression
             {
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:850:13: ( ASSIGN | PLUS_ASSIGN | MINUS_ASSIGN
-              // | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN | SHIFT_LEFT_ASSIGN |
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:850:13: ( ASSIGN |
+              // PLUS_ASSIGN | MINUS_ASSIGN
+              // | STAR_ASSIGN | DIV_ASSIGN | AND_ASSIGN | OR_ASSIGN | XOR_ASSIGN | MOD_ASSIGN |
+              // SHIFT_LEFT_ASSIGN |
               // SHIFT_RIGHT_ASSIGN | BIT_SHIFT_RIGHT_ASSIGN )
               int alt107 = 12;
               switch (input.LA(1)) {
@@ -15066,7 +15711,8 @@ public class JavaParser extends Parser {
                   }
                   break;
                 case 10:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:859:17: SHIFT_LEFT_ASSIGN
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:859:17:
+                  // SHIFT_LEFT_ASSIGN
                   {
                     SHIFT_LEFT_ASSIGN378 =
                         (Token)
@@ -15082,7 +15728,8 @@ public class JavaParser extends Parser {
                   }
                   break;
                 case 11:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:860:17: SHIFT_RIGHT_ASSIGN
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:860:17:
+                  // SHIFT_RIGHT_ASSIGN
                   {
                     SHIFT_RIGHT_ASSIGN379 =
                         (Token)
@@ -15099,7 +15746,8 @@ public class JavaParser extends Parser {
                   }
                   break;
                 case 12:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:861:17: BIT_SHIFT_RIGHT_ASSIGN
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:861:17:
+                  // BIT_SHIFT_RIGHT_ASSIGN
                   {
                     BIT_SHIFT_RIGHT_ASSIGN380 =
                         (Token)
@@ -15160,7 +15808,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "conditionalExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:866:1: conditionalExpression : logicalOrExpression ( QUESTION
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:866:1: conditionalExpression :
+  // logicalOrExpression ( QUESTION
   // assignmentExpression COLON conditionalExpression )? ;
   public final JavaParser.conditionalExpression_return conditionalExpression()
       throws RecognitionException {
@@ -15184,9 +15833,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 90)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:867:5: ( logicalOrExpression ( QUESTION
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:867:5: ( logicalOrExpression (
+      // QUESTION
       // assignmentExpression COLON conditionalExpression )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:867:9: logicalOrExpression ( QUESTION assignmentExpression
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:867:9: logicalOrExpression (
+      // QUESTION assignmentExpression
       // COLON conditionalExpression )?
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -15197,7 +15848,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, logicalOrExpression382.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:867:29: ( QUESTION assignmentExpression COLON
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:867:29: ( QUESTION
+        // assignmentExpression COLON
         // conditionalExpression )?
         int alt109 = 2;
         int LA109_0 = input.LA(1);
@@ -15207,7 +15859,8 @@ public class JavaParser extends Parser {
         }
         switch (alt109) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:867:30: QUESTION assignmentExpression COLON
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:867:30: QUESTION
+            // assignmentExpression COLON
             // conditionalExpression
             {
               QUESTION383 =
@@ -15268,7 +15921,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "logicalOrExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:870:1: logicalOrExpression : logicalAndExpression ( LOGICAL_OR
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:870:1: logicalOrExpression :
+  // logicalAndExpression ( LOGICAL_OR
   // logicalAndExpression )* ;
   public final JavaParser.logicalOrExpression_return logicalOrExpression()
       throws RecognitionException {
@@ -15288,9 +15942,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 91)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:871:5: ( logicalAndExpression ( LOGICAL_OR
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:871:5: ( logicalAndExpression (
+      // LOGICAL_OR
       // logicalAndExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:871:9: logicalAndExpression ( LOGICAL_OR
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:871:9: logicalAndExpression (
+      // LOGICAL_OR
       // logicalAndExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -15301,7 +15957,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, logicalAndExpression387.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:871:30: ( LOGICAL_OR logicalAndExpression )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:871:30: ( LOGICAL_OR
+        // logicalAndExpression )*
         loop110:
         do {
           int alt110 = 2;
@@ -15313,7 +15970,8 @@ public class JavaParser extends Parser {
 
           switch (alt110) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:871:31: LOGICAL_OR logicalAndExpression
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:871:31: LOGICAL_OR
+              // logicalAndExpression
               {
                 LOGICAL_OR388 =
                     (Token) match(input, LOGICAL_OR, FOLLOW_LOGICAL_OR_in_logicalOrExpression10838);
@@ -15368,7 +16026,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "logicalAndExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:874:1: logicalAndExpression : inclusiveOrExpression ( LOGICAL_AND
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:874:1: logicalAndExpression :
+  // inclusiveOrExpression ( LOGICAL_AND
   // inclusiveOrExpression )* ;
   public final JavaParser.logicalAndExpression_return logicalAndExpression()
       throws RecognitionException {
@@ -15388,9 +16047,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 92)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:875:5: ( inclusiveOrExpression ( LOGICAL_AND
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:875:5: ( inclusiveOrExpression (
+      // LOGICAL_AND
       // inclusiveOrExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:875:9: inclusiveOrExpression ( LOGICAL_AND
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:875:9: inclusiveOrExpression (
+      // LOGICAL_AND
       // inclusiveOrExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -15401,7 +16062,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, inclusiveOrExpression390.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:875:31: ( LOGICAL_AND inclusiveOrExpression )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:875:31: ( LOGICAL_AND
+        // inclusiveOrExpression )*
         loop111:
         do {
           int alt111 = 2;
@@ -15413,7 +16075,8 @@ public class JavaParser extends Parser {
 
           switch (alt111) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:875:32: LOGICAL_AND inclusiveOrExpression
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:875:32: LOGICAL_AND
+              // inclusiveOrExpression
               {
                 LOGICAL_AND391 =
                     (Token)
@@ -15469,7 +16132,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "inclusiveOrExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:878:1: inclusiveOrExpression : exclusiveOrExpression ( OR
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:878:1: inclusiveOrExpression :
+  // exclusiveOrExpression ( OR
   // exclusiveOrExpression )* ;
   public final JavaParser.inclusiveOrExpression_return inclusiveOrExpression()
       throws RecognitionException {
@@ -15489,9 +16153,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 93)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:879:5: ( exclusiveOrExpression ( OR exclusiveOrExpression
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:879:5: ( exclusiveOrExpression (
+      // OR exclusiveOrExpression
       // )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:879:9: exclusiveOrExpression ( OR exclusiveOrExpression )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:879:9: exclusiveOrExpression ( OR
+      // exclusiveOrExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -15501,7 +16167,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, exclusiveOrExpression393.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:879:31: ( OR exclusiveOrExpression )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:879:31: ( OR
+        // exclusiveOrExpression )*
         loop112:
         do {
           int alt112 = 2;
@@ -15513,7 +16180,8 @@ public class JavaParser extends Parser {
 
           switch (alt112) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:879:32: OR exclusiveOrExpression
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:879:32: OR
+              // exclusiveOrExpression
               {
                 OR394 = (Token) match(input, OR, FOLLOW_OR_in_inclusiveOrExpression10892);
                 if (state.failed) return retval;
@@ -15567,7 +16235,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "exclusiveOrExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:882:1: exclusiveOrExpression : andExpression ( XOR andExpression )* ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:882:1: exclusiveOrExpression :
+  // andExpression ( XOR andExpression )* ;
   public final JavaParser.exclusiveOrExpression_return exclusiveOrExpression()
       throws RecognitionException {
     JavaParser.exclusiveOrExpression_return retval = new JavaParser.exclusiveOrExpression_return();
@@ -15586,8 +16255,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 94)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:883:5: ( andExpression ( XOR andExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:883:9: andExpression ( XOR andExpression )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:883:5: ( andExpression ( XOR
+      // andExpression )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:883:9: andExpression ( XOR
+      // andExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -15662,7 +16333,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "andExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:886:1: andExpression : equalityExpression ( AND equalityExpression
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:886:1: andExpression :
+  // equalityExpression ( AND equalityExpression
   // )* ;
   public final JavaParser.andExpression_return andExpression() throws RecognitionException {
     JavaParser.andExpression_return retval = new JavaParser.andExpression_return();
@@ -15681,8 +16353,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 95)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:887:5: ( equalityExpression ( AND equalityExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:887:9: equalityExpression ( AND equalityExpression )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:887:5: ( equalityExpression ( AND
+      // equalityExpression )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:887:9: equalityExpression ( AND
+      // equalityExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -15692,7 +16366,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, equalityExpression399.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:887:28: ( AND equalityExpression )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:887:28: ( AND
+        // equalityExpression )*
         loop114:
         do {
           int alt114 = 2;
@@ -15704,7 +16379,8 @@ public class JavaParser extends Parser {
 
           switch (alt114) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:887:29: AND equalityExpression
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:887:29: AND
+              // equalityExpression
               {
                 AND400 = (Token) match(input, AND, FOLLOW_AND_in_andExpression10946);
                 if (state.failed) return retval;
@@ -15758,7 +16434,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "equalityExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:890:1: equalityExpression : instanceOfExpression ( ( EQUAL |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:890:1: equalityExpression :
+  // instanceOfExpression ( ( EQUAL |
   // NOT_EQUAL ) instanceOfExpression )* ;
   public final JavaParser.equalityExpression_return equalityExpression()
       throws RecognitionException {
@@ -15780,9 +16457,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 96)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:891:5: ( instanceOfExpression ( ( EQUAL | NOT_EQUAL )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:891:5: ( instanceOfExpression ( (
+      // EQUAL | NOT_EQUAL )
       // instanceOfExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:891:9: instanceOfExpression ( ( EQUAL | NOT_EQUAL )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:891:9: instanceOfExpression ( (
+      // EQUAL | NOT_EQUAL )
       // instanceOfExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -15793,7 +16472,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, instanceOfExpression402.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:892:9: ( ( EQUAL | NOT_EQUAL ) instanceOfExpression )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:892:9: ( ( EQUAL | NOT_EQUAL )
+        // instanceOfExpression )*
         loop116:
         do {
           int alt116 = 2;
@@ -15805,10 +16485,12 @@ public class JavaParser extends Parser {
 
           switch (alt116) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:892:13: ( EQUAL | NOT_EQUAL )
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:892:13: ( EQUAL |
+              // NOT_EQUAL )
               // instanceOfExpression
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:892:13: ( EQUAL | NOT_EQUAL )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:892:13: ( EQUAL |
+                // NOT_EQUAL )
                 int alt115 = 2;
                 int LA115_0 = input.LA(1);
 
@@ -15899,7 +16581,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "instanceOfExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:899:1: instanceOfExpression : relationalExpression ( INSTANCEOF
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:899:1: instanceOfExpression :
+  // relationalExpression ( INSTANCEOF
   // type )? ;
   public final JavaParser.instanceOfExpression_return instanceOfExpression()
       throws RecognitionException {
@@ -15919,8 +16602,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 97)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:900:5: ( relationalExpression ( INSTANCEOF type )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:900:9: relationalExpression ( INSTANCEOF type )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:900:5: ( relationalExpression (
+      // INSTANCEOF type )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:900:9: relationalExpression (
+      // INSTANCEOF type )?
       {
         root_0 = (CommonTree) adaptor.nil();
 
@@ -15989,7 +16674,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "relationalExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:903:1: relationalExpression : shiftExpression ( ( LESS_OR_EQUAL |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:903:1: relationalExpression :
+  // shiftExpression ( ( LESS_OR_EQUAL |
   // GREATER_OR_EQUAL | LESS_THAN | GREATER_THAN ) shiftExpression )* ;
   public final JavaParser.relationalExpression_return relationalExpression()
       throws RecognitionException {
@@ -16015,9 +16701,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 98)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:904:5: ( shiftExpression ( ( LESS_OR_EQUAL |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:904:5: ( shiftExpression ( (
+      // LESS_OR_EQUAL |
       // GREATER_OR_EQUAL | LESS_THAN | GREATER_THAN ) shiftExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:904:9: shiftExpression ( ( LESS_OR_EQUAL |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:904:9: shiftExpression ( (
+      // LESS_OR_EQUAL |
       // GREATER_OR_EQUAL | LESS_THAN | GREATER_THAN ) shiftExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -16028,7 +16716,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, shiftExpression409.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:905:9: ( ( LESS_OR_EQUAL | GREATER_OR_EQUAL |
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:905:9: ( ( LESS_OR_EQUAL |
+        // GREATER_OR_EQUAL |
         // LESS_THAN | GREATER_THAN ) shiftExpression )*
         loop119:
         do {
@@ -16042,10 +16731,12 @@ public class JavaParser extends Parser {
 
           switch (alt119) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:905:13: ( LESS_OR_EQUAL | GREATER_OR_EQUAL
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:905:13: ( LESS_OR_EQUAL |
+              // GREATER_OR_EQUAL
               // | LESS_THAN | GREATER_THAN ) shiftExpression
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:905:13: ( LESS_OR_EQUAL | GREATER_OR_EQUAL
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:905:13: ( LESS_OR_EQUAL
+                // | GREATER_OR_EQUAL
                 // | LESS_THAN | GREATER_THAN )
                 int alt118 = 4;
                 switch (input.LA(1)) {
@@ -16081,7 +16772,8 @@ public class JavaParser extends Parser {
 
                 switch (alt118) {
                   case 1:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:905:17: LESS_OR_EQUAL
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:905:17:
+                    // LESS_OR_EQUAL
                     {
                       LESS_OR_EQUAL410 =
                           (Token)
@@ -16097,7 +16789,8 @@ public class JavaParser extends Parser {
                     }
                     break;
                   case 2:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:906:17: GREATER_OR_EQUAL
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:906:17:
+                    // GREATER_OR_EQUAL
                     {
                       GREATER_OR_EQUAL411 =
                           (Token)
@@ -16127,7 +16820,8 @@ public class JavaParser extends Parser {
                     }
                     break;
                   case 4:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:908:17: GREATER_THAN
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:908:17:
+                    // GREATER_THAN
                     {
                       GREATER_THAN413 =
                           (Token)
@@ -16189,7 +16883,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "shiftExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:914:1: shiftExpression : additiveExpression ( ( BIT_SHIFT_RIGHT |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:914:1: shiftExpression :
+  // additiveExpression ( ( BIT_SHIFT_RIGHT |
   // SHIFT_RIGHT | SHIFT_LEFT ) additiveExpression )* ;
   public final JavaParser.shiftExpression_return shiftExpression() throws RecognitionException {
     JavaParser.shiftExpression_return retval = new JavaParser.shiftExpression_return();
@@ -16212,9 +16907,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 99)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:915:5: ( additiveExpression ( ( BIT_SHIFT_RIGHT |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:915:5: ( additiveExpression ( (
+      // BIT_SHIFT_RIGHT |
       // SHIFT_RIGHT | SHIFT_LEFT ) additiveExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:915:9: additiveExpression ( ( BIT_SHIFT_RIGHT |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:915:9: additiveExpression ( (
+      // BIT_SHIFT_RIGHT |
       // SHIFT_RIGHT | SHIFT_LEFT ) additiveExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -16225,7 +16922,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, additiveExpression415.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:916:9: ( ( BIT_SHIFT_RIGHT | SHIFT_RIGHT | SHIFT_LEFT
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:916:9: ( ( BIT_SHIFT_RIGHT |
+        // SHIFT_RIGHT | SHIFT_LEFT
         // ) additiveExpression )*
         loop121:
         do {
@@ -16238,10 +16936,12 @@ public class JavaParser extends Parser {
 
           switch (alt121) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:916:13: ( BIT_SHIFT_RIGHT | SHIFT_RIGHT |
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:916:13: ( BIT_SHIFT_RIGHT
+              // | SHIFT_RIGHT |
               // SHIFT_LEFT ) additiveExpression
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:916:13: ( BIT_SHIFT_RIGHT | SHIFT_RIGHT |
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:916:13: (
+                // BIT_SHIFT_RIGHT | SHIFT_RIGHT |
                 // SHIFT_LEFT )
                 int alt120 = 3;
                 switch (input.LA(1)) {
@@ -16272,7 +16972,8 @@ public class JavaParser extends Parser {
 
                 switch (alt120) {
                   case 1:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:916:17: BIT_SHIFT_RIGHT
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:916:17:
+                    // BIT_SHIFT_RIGHT
                     {
                       BIT_SHIFT_RIGHT416 =
                           (Token)
@@ -16361,7 +17062,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "additiveExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:924:1: additiveExpression : multiplicativeExpression ( ( PLUS |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:924:1: additiveExpression :
+  // multiplicativeExpression ( ( PLUS |
   // MINUS ) multiplicativeExpression )* ;
   public final JavaParser.additiveExpression_return additiveExpression()
       throws RecognitionException {
@@ -16383,9 +17085,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 100)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:925:5: ( multiplicativeExpression ( ( PLUS | MINUS )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:925:5: ( multiplicativeExpression
+      // ( ( PLUS | MINUS )
       // multiplicativeExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:925:9: multiplicativeExpression ( ( PLUS | MINUS )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:925:9: multiplicativeExpression (
+      // ( PLUS | MINUS )
       // multiplicativeExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -16397,7 +17101,8 @@ public class JavaParser extends Parser {
         if (state.failed) return retval;
         if (state.backtracking == 0)
           adaptor.addChild(root_0, multiplicativeExpression420.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:926:9: ( ( PLUS | MINUS ) multiplicativeExpression )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:926:9: ( ( PLUS | MINUS )
+        // multiplicativeExpression )*
         loop123:
         do {
           int alt123 = 2;
@@ -16412,7 +17117,8 @@ public class JavaParser extends Parser {
               // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:926:13: ( PLUS | MINUS )
               // multiplicativeExpression
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:926:13: ( PLUS | MINUS )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:926:13: ( PLUS | MINUS
+                // )
                 int alt122 = 2;
                 int LA122_0 = input.LA(1);
 
@@ -16501,7 +17207,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "multiplicativeExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:933:1: multiplicativeExpression : unaryExpression ( ( STAR | DIV |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:933:1: multiplicativeExpression :
+  // unaryExpression ( ( STAR | DIV |
   // MOD ) unaryExpression )* ;
   public final JavaParser.multiplicativeExpression_return multiplicativeExpression()
       throws RecognitionException {
@@ -16526,9 +17233,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 101)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:934:5: ( unaryExpression ( ( STAR | DIV | MOD )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:934:5: ( unaryExpression ( ( STAR
+      // | DIV | MOD )
       // unaryExpression )* )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:934:9: unaryExpression ( ( STAR | DIV | MOD )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:934:9: unaryExpression ( ( STAR |
+      // DIV | MOD )
       // unaryExpression )*
       {
         root_0 = (CommonTree) adaptor.nil();
@@ -16539,7 +17248,8 @@ public class JavaParser extends Parser {
         state._fsp--;
         if (state.failed) return retval;
         if (state.backtracking == 0) adaptor.addChild(root_0, unaryExpression424.getTree());
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:935:9: ( ( STAR | DIV | MOD ) unaryExpression )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:935:9: ( ( STAR | DIV | MOD )
+        // unaryExpression )*
         loop125:
         do {
           int alt125 = 2;
@@ -16551,9 +17261,11 @@ public class JavaParser extends Parser {
 
           switch (alt125) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:935:13: ( STAR | DIV | MOD ) unaryExpression
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:935:13: ( STAR | DIV |
+              // MOD ) unaryExpression
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:935:13: ( STAR | DIV | MOD )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:935:13: ( STAR | DIV |
+                // MOD )
                 int alt124 = 3;
                 switch (input.LA(1)) {
                   case STAR:
@@ -16665,10 +17377,14 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "unaryExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:943:1: unaryExpression : ( PLUS unaryExpression -> ^(
-  // UNARY_PLUS[$PLUS, \"UNARY_PLUS\"] unaryExpression ) | MINUS unaryExpression -> ^( UNARY_MINUS[$MINUS,
-  // \"UNARY_MINUS\"] unaryExpression ) | INC postfixedExpression -> ^( PRE_INC[$INC, \"PRE_INC\"] postfixedExpression ) | DEC
-  // postfixedExpression -> ^( PRE_DEC[$DEC, \"PRE_DEC\"] postfixedExpression ) | unaryExpressionNotPlusMinus );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:943:1: unaryExpression : ( PLUS
+  // unaryExpression -> ^(
+  // UNARY_PLUS[$PLUS, \"UNARY_PLUS\"] unaryExpression ) | MINUS unaryExpression -> ^(
+  // UNARY_MINUS[$MINUS,
+  // \"UNARY_MINUS\"] unaryExpression ) | INC postfixedExpression -> ^( PRE_INC[$INC, \"PRE_INC\"]
+  // postfixedExpression ) | DEC
+  // postfixedExpression -> ^( PRE_DEC[$DEC, \"PRE_DEC\"] postfixedExpression ) |
+  // unaryExpressionNotPlusMinus );
   public final JavaParser.unaryExpression_return unaryExpression() throws RecognitionException {
     JavaParser.unaryExpression_return retval = new JavaParser.unaryExpression_return();
     retval.start = input.LT(1);
@@ -16705,10 +17421,13 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 102)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:944:5: ( PLUS unaryExpression -> ^( UNARY_PLUS[$PLUS,
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:944:5: ( PLUS unaryExpression ->
+      // ^( UNARY_PLUS[$PLUS,
       // \"UNARY_PLUS\"] unaryExpression ) | MINUS unaryExpression -> ^( UNARY_MINUS[$MINUS,
-      // \"UNARY_MINUS\"] unaryExpression ) | INC postfixedExpression -> ^( PRE_INC[$INC, \"PRE_INC\"] postfixedExpression ) | DEC
-      // postfixedExpression -> ^( PRE_DEC[$DEC, \"PRE_DEC\"] postfixedExpression ) | unaryExpressionNotPlusMinus )
+      // \"UNARY_MINUS\"] unaryExpression ) | INC postfixedExpression -> ^( PRE_INC[$INC,
+      // \"PRE_INC\"] postfixedExpression ) | DEC
+      // postfixedExpression -> ^( PRE_DEC[$DEC, \"PRE_DEC\"] postfixedExpression ) |
+      // unaryExpressionNotPlusMinus )
       int alt126 = 5;
       switch (input.LA(1)) {
         case PLUS:
@@ -16802,7 +17521,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 944:37: -> ^( UNARY_PLUS[$PLUS, \"UNARY_PLUS\"] unaryExpression )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:944:41: ^( UNARY_PLUS[$PLUS,
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:944:41: ^(
+                // UNARY_PLUS[$PLUS,
                 // \"UNARY_PLUS\"] unaryExpression )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -16852,7 +17572,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 945:37: -> ^( UNARY_MINUS[$MINUS, \"UNARY_MINUS\"] unaryExpression )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:945:41: ^( UNARY_MINUS[$MINUS,
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:945:41: ^(
+                // UNARY_MINUS[$MINUS,
                 // \"UNARY_MINUS\"] unaryExpression )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -16873,7 +17594,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:946:9: INC postfixedExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:946:9: INC
+          // postfixedExpression
           {
             INC433 = (Token) match(input, INC, FOLLOW_INC_in_unaryExpression11622);
             if (state.failed) return retval;
@@ -16903,7 +17625,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 946:37: -> ^( PRE_INC[$INC, \"PRE_INC\"] postfixedExpression )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:946:41: ^( PRE_INC[$INC,
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:946:41: ^(
+                // PRE_INC[$INC,
                 // \"PRE_INC\"] postfixedExpression )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -16923,7 +17646,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:947:9: DEC postfixedExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:947:9: DEC
+          // postfixedExpression
           {
             DEC435 = (Token) match(input, DEC, FOLLOW_DEC_in_unaryExpression11648);
             if (state.failed) return retval;
@@ -16953,7 +17677,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 947:37: -> ^( PRE_DEC[$DEC, \"PRE_DEC\"] postfixedExpression )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:947:41: ^( PRE_DEC[$DEC,
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:947:41: ^(
+                // PRE_DEC[$DEC,
                 // \"PRE_DEC\"] postfixedExpression )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -16973,7 +17698,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 5:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:948:9: unaryExpressionNotPlusMinus
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:948:9:
+          // unaryExpressionNotPlusMinus
           {
             root_0 = (CommonTree) adaptor.nil();
 
@@ -17017,8 +17743,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "unaryExpressionNotPlusMinus"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:951:1: unaryExpressionNotPlusMinus : ( NOT unaryExpression -> ^(
-  // NOT unaryExpression ) | LOGICAL_NOT unaryExpression -> ^( LOGICAL_NOT unaryExpression ) | LPAREN type RPAREN unaryExpression -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:951:1: unaryExpressionNotPlusMinus :
+  // ( NOT unaryExpression -> ^(
+  // NOT unaryExpression ) | LOGICAL_NOT unaryExpression -> ^( LOGICAL_NOT unaryExpression ) |
+  // LPAREN type RPAREN unaryExpression -> ^(
   // CAST_EXPR[$LPAREN, \"CAST_EXPR\"] type unaryExpression ) | postfixedExpression );
   public final JavaParser.unaryExpressionNotPlusMinus_return unaryExpressionNotPlusMinus()
       throws RecognitionException {
@@ -17058,8 +17786,10 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 103)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:952:5: ( NOT unaryExpression -> ^( NOT unaryExpression ) |
-      // LOGICAL_NOT unaryExpression -> ^( LOGICAL_NOT unaryExpression ) | LPAREN type RPAREN unaryExpression -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:952:5: ( NOT unaryExpression ->
+      // ^( NOT unaryExpression ) |
+      // LOGICAL_NOT unaryExpression -> ^( LOGICAL_NOT unaryExpression ) | LPAREN type RPAREN
+      // unaryExpression -> ^(
       // CAST_EXPR[$LPAREN, \"CAST_EXPR\"] type unaryExpression ) | postfixedExpression )
       int alt127 = 4;
       alt127 = dfa127.predict(input);
@@ -17094,7 +17824,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 952:57: -> ^( NOT unaryExpression )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:952:61: ^( NOT unaryExpression )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:952:61: ^( NOT
+                // unaryExpression )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_NOT.nextNode(), root_1);
@@ -17110,7 +17841,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:953:9: LOGICAL_NOT unaryExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:953:9: LOGICAL_NOT
+          // unaryExpression
           {
             LOGICAL_NOT440 =
                 (Token)
@@ -17142,7 +17874,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 953:57: -> ^( LOGICAL_NOT unaryExpression )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:953:61: ^( LOGICAL_NOT unaryExpression )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:953:61: ^( LOGICAL_NOT
+                // unaryExpression )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_LOGICAL_NOT.nextNode(), root_1);
@@ -17158,7 +17891,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:954:9: LPAREN type RPAREN unaryExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:954:9: LPAREN type RPAREN
+          // unaryExpression
           {
             LPAREN442 =
                 (Token) match(input, LPAREN, FOLLOW_LPAREN_in_unaryExpressionNotPlusMinus11783);
@@ -17199,7 +17933,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 954:57: -> ^( CAST_EXPR[$LPAREN, \"CAST_EXPR\"] type unaryExpression )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:954:61: ^( CAST_EXPR[$LPAREN,
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:954:61: ^(
+                // CAST_EXPR[$LPAREN,
                 // \"CAST_EXPR\"] type unaryExpression )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -17264,14 +17999,21 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "postfixedExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:958:1: postfixedExpression : ( primaryExpression ->
-  // primaryExpression ) (outerDot= DOT ( ( ( genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) ) (
-  // arguments -> ^( METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? | THIS -> ^( DOT
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:958:1: postfixedExpression : (
+  // primaryExpression ->
+  // primaryExpression ) (outerDot= DOT ( ( ( genericTypeArgumentListSimplified )? IDENT -> ^( DOT
+  // $postfixedExpression IDENT ) ) (
+  // arguments -> ^( METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )?
+  // arguments ) )? | THIS -> ^( DOT
   // $postfixedExpression THIS ) | Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-  // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot= DOT IDENT -> ^( $innerDot ^( $outerDot
-  // $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL $postfixedExpression arguments ) )? | innerNewExpression -> ^
-  // ( DOT $postfixedExpression innerNewExpression ) ) | LBRACK expression RBRACK -> ^( ARRAY_ELEMENT_ACCESS $postfixedExpression
-  // expression ) )* ( INC -> ^( POST_INC[$INC, \"POST_INC\"] $postfixedExpression) | DEC -> ^( POST_DEC[$DEC,
+  // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot= DOT IDENT ->
+  // ^( $innerDot ^( $outerDot
+  // $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL $postfixedExpression
+  // arguments ) )? | innerNewExpression -> ^
+  // ( DOT $postfixedExpression innerNewExpression ) ) | LBRACK expression RBRACK -> ^(
+  // ARRAY_ELEMENT_ACCESS $postfixedExpression
+  // expression ) )* ( INC -> ^( POST_INC[$INC, \"POST_INC\"] $postfixedExpression) | DEC -> ^(
+  // POST_DEC[$DEC,
   // \"POST_DEC\"] $postfixedExpression) )? ;
   public final JavaParser.postfixedExpression_return postfixedExpression()
       throws RecognitionException {
@@ -17338,26 +18080,41 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 104)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:960:5: ( ( primaryExpression -> primaryExpression )
-      // (outerDot= DOT ( ( ( genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) ) ( arguments -> ^(
-      // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? | THIS -> ^( DOT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:960:5: ( ( primaryExpression ->
+      // primaryExpression )
+      // (outerDot= DOT ( ( ( genericTypeArgumentListSimplified )? IDENT -> ^( DOT
+      // $postfixedExpression IDENT ) ) ( arguments -> ^(
+      // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? |
+      // THIS -> ^( DOT
       // $postfixedExpression THIS ) | Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-      // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot= DOT IDENT -> ^( $innerDot ^( $outerDot
-      // $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL $postfixedExpression arguments ) )? |
-      // innerNewExpression -> ^( DOT $postfixedExpression innerNewExpression ) ) | LBRACK expression RBRACK -> ^(
+      // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot= DOT IDENT
+      // -> ^( $innerDot ^( $outerDot
+      // $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL $postfixedExpression
+      // arguments ) )? |
+      // innerNewExpression -> ^( DOT $postfixedExpression innerNewExpression ) ) | LBRACK
+      // expression RBRACK -> ^(
       // ARRAY_ELEMENT_ACCESS $postfixedExpression expression ) )* ( INC -> ^( POST_INC[$INC,
-      // \"POST_INC\"] $postfixedExpression) | DEC -> ^( POST_DEC[$DEC, \"POST_DEC\"] $postfixedExpression) )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:960:9: ( primaryExpression -> primaryExpression )
-      // (outerDot= DOT ( ( ( genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) ) ( arguments -> ^(
-      // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? | THIS -> ^( DOT
+      // \"POST_INC\"] $postfixedExpression) | DEC -> ^( POST_DEC[$DEC, \"POST_DEC\"]
+      // $postfixedExpression) )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:960:9: ( primaryExpression ->
+      // primaryExpression )
+      // (outerDot= DOT ( ( ( genericTypeArgumentListSimplified )? IDENT -> ^( DOT
+      // $postfixedExpression IDENT ) ) ( arguments -> ^(
+      // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? |
+      // THIS -> ^( DOT
       // $postfixedExpression THIS ) | Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-      // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot= DOT IDENT -> ^( $innerDot ^( $outerDot
-      // $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL $postfixedExpression arguments ) )? |
-      // innerNewExpression -> ^( DOT $postfixedExpression innerNewExpression ) ) | LBRACK expression RBRACK -> ^(
+      // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot= DOT IDENT
+      // -> ^( $innerDot ^( $outerDot
+      // $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL $postfixedExpression
+      // arguments ) )? |
+      // innerNewExpression -> ^( DOT $postfixedExpression innerNewExpression ) ) | LBRACK
+      // expression RBRACK -> ^(
       // ARRAY_ELEMENT_ACCESS $postfixedExpression expression ) )* ( INC -> ^( POST_INC[$INC,
-      // \"POST_INC\"] $postfixedExpression) | DEC -> ^( POST_DEC[$DEC, \"POST_DEC\"] $postfixedExpression) )?
+      // \"POST_INC\"] $postfixedExpression) | DEC -> ^( POST_DEC[$DEC, \"POST_DEC\"]
+      // $postfixedExpression) )?
       {
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:960:9: ( primaryExpression -> primaryExpression )
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:960:9: ( primaryExpression ->
+        // primaryExpression )
         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:960:13: primaryExpression
         {
           pushFollow(FOLLOW_primaryExpression_in_postfixedExpression11860);
@@ -17391,12 +18148,18 @@ public class JavaParser extends Parser {
         }
 
         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:963:9: (outerDot= DOT ( ( (
-        // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) ) ( arguments -> ^( METHOD_CALL
-        // $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? | THIS -> ^( DOT $postfixedExpression THIS
-        // ) | Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression
-        // arguments ) | ( SUPER innerDot= DOT IDENT -> ^( $innerDot ^( $outerDot $postfixedExpression SUPER ) IDENT ) ) (
-        // arguments -> ^( METHOD_CALL $postfixedExpression arguments ) )? | innerNewExpression -> ^( DOT $postfixedExpression
-        // innerNewExpression ) ) | LBRACK expression RBRACK -> ^( ARRAY_ELEMENT_ACCESS $postfixedExpression expression ) )*
+        // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) ) (
+        // arguments -> ^( METHOD_CALL
+        // $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? | THIS -> ^(
+        // DOT $postfixedExpression THIS
+        // ) | Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
+        // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression
+        // arguments ) | ( SUPER innerDot= DOT IDENT -> ^( $innerDot ^( $outerDot
+        // $postfixedExpression SUPER ) IDENT ) ) (
+        // arguments -> ^( METHOD_CALL $postfixedExpression arguments ) )? | innerNewExpression ->
+        // ^( DOT $postfixedExpression
+        // innerNewExpression ) ) | LBRACK expression RBRACK -> ^( ARRAY_ELEMENT_ACCESS
+        // $postfixedExpression expression ) )*
         loop132:
         do {
           int alt132 = 3;
@@ -17410,25 +18173,38 @@ public class JavaParser extends Parser {
 
           switch (alt132) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:963:13: outerDot= DOT ( ( (
-              // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) ) ( arguments -> ^(
-              // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? | THIS -> ^( DOT
-              // $postfixedExpression THIS ) | Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-              // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot= DOT IDENT -> ^( $innerDot
-              // ^( $outerDot $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL $postfixedExpression
-              // arguments ) )? | innerNewExpression -> ^( DOT $postfixedExpression innerNewExpression ) )
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:963:13: outerDot= DOT ( (
+              // (
+              // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) )
+              // ( arguments -> ^(
+              // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments )
+              // )? | THIS -> ^( DOT
+              // $postfixedExpression THIS ) | Super= SUPER arguments -> ^(
+              // SUPER_CONSTRUCTOR_CALL[$Super,
+              // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot=
+              // DOT IDENT -> ^( $innerDot
+              // ^( $outerDot $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL
+              // $postfixedExpression
+              // arguments ) )? | innerNewExpression -> ^( DOT $postfixedExpression
+              // innerNewExpression ) )
               {
                 outerDot = (Token) match(input, DOT, FOLLOW_DOT_in_postfixedExpression11922);
                 if (state.failed) return retval;
                 if (state.backtracking == 0) stream_DOT.add(outerDot);
 
                 // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:964:13: ( ( (
-                // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) ) ( arguments -> ^(
-                // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )? | THIS -> ^( DOT
-                // $postfixedExpression THIS ) | Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-                // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot= DOT IDENT -> ^( $innerDot
-                // ^( $outerDot $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL $postfixedExpression
-                // arguments ) )? | innerNewExpression -> ^( DOT $postfixedExpression innerNewExpression ) )
+                // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT )
+                // ) ( arguments -> ^(
+                // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments
+                // ) )? | THIS -> ^( DOT
+                // $postfixedExpression THIS ) | Super= SUPER arguments -> ^(
+                // SUPER_CONSTRUCTOR_CALL[$Super,
+                // \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments ) | ( SUPER innerDot=
+                // DOT IDENT -> ^( $innerDot
+                // ^( $outerDot $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^( METHOD_CALL
+                // $postfixedExpression
+                // arguments ) )? | innerNewExpression -> ^( DOT $postfixedExpression
+                // innerNewExpression ) )
                 int alt131 = 5;
                 switch (input.LA(1)) {
                   case LESS_THAN:
@@ -17479,11 +18255,14 @@ public class JavaParser extends Parser {
                 switch (alt131) {
                   case 1:
                     // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:964:17: ( (
-                    // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) ) ( arguments ->
-                    // ^( METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )?
+                    // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression
+                    // IDENT ) ) ( arguments ->
+                    // ^( METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )?
+                    // arguments ) )?
                     {
                       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:964:17: ( (
-                      // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression IDENT ) )
+                      // genericTypeArgumentListSimplified )? IDENT -> ^( DOT $postfixedExpression
+                      // IDENT ) )
                       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:964:21: (
                       // genericTypeArgumentListSimplified )? IDENT
                       {
@@ -17535,7 +18314,8 @@ public class JavaParser extends Parser {
                           root_0 = (CommonTree) adaptor.nil();
                           // 966:53: -> ^( DOT $postfixedExpression IDENT )
                           {
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:966:57: ^( DOT
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:966:57: ^(
+                            // DOT
                             // $postfixedExpression IDENT )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -17553,8 +18333,10 @@ public class JavaParser extends Parser {
                         }
                       }
 
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:968:17: ( arguments -> ^(
-                      // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments ) )?
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:968:17: (
+                      // arguments -> ^(
+                      // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )?
+                      // arguments ) )?
                       int alt129 = 2;
                       int LA129_0 = input.LA(1);
 
@@ -17563,7 +18345,8 @@ public class JavaParser extends Parser {
                       }
                       switch (alt129) {
                         case 1:
-                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:968:21: arguments
+                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:968:21:
+                          // arguments
                           {
                             pushFollow(FOLLOW_arguments_in_postfixedExpression12133);
                             arguments450 = arguments();
@@ -17574,7 +18357,8 @@ public class JavaParser extends Parser {
                               stream_arguments.add(arguments450.getTree());
 
                             // AST REWRITE
-                            // elements: postfixedExpression, arguments, genericTypeArgumentListSimplified
+                            // elements: postfixedExpression, arguments,
+                            // genericTypeArgumentListSimplified
                             // token labels:
                             // rule labels: retval
                             // token list labels:
@@ -17587,11 +18371,14 @@ public class JavaParser extends Parser {
                                       adaptor, "rule retval", retval != null ? retval.tree : null);
 
                               root_0 = (CommonTree) adaptor.nil();
-                              // 968:53: -> ^( METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )?
+                              // 968:53: -> ^( METHOD_CALL $postfixedExpression (
+                              // genericTypeArgumentListSimplified )?
                               // arguments )
                               {
-                                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:968:57: ^(
-                                // METHOD_CALL $postfixedExpression ( genericTypeArgumentListSimplified )? arguments )
+                                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:968:57:
+                                // ^(
+                                // METHOD_CALL $postfixedExpression (
+                                // genericTypeArgumentListSimplified )? arguments )
                                 {
                                   CommonTree root_1 = (CommonTree) adaptor.nil();
                                   root_1 =
@@ -17646,7 +18433,8 @@ public class JavaParser extends Parser {
                         root_0 = (CommonTree) adaptor.nil();
                         // 970:53: -> ^( DOT $postfixedExpression THIS )
                         {
-                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:970:57: ^( DOT
+                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:970:57: ^(
+                          // DOT
                           // $postfixedExpression THIS )
                           {
                             CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -17664,7 +18452,8 @@ public class JavaParser extends Parser {
                     }
                     break;
                   case 3:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:971:17: Super= SUPER arguments
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:971:17: Super=
+                    // SUPER arguments
                     {
                       Super = (Token) match(input, SUPER, FOLLOW_SUPER_in_postfixedExpression12270);
                       if (state.failed) return retval;
@@ -17691,11 +18480,13 @@ public class JavaParser extends Parser {
                                 adaptor, "rule retval", retval != null ? retval.tree : null);
 
                         root_0 = (CommonTree) adaptor.nil();
-                        // 971:57: -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression
+                        // 971:57: -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"]
+                        // $postfixedExpression
                         // arguments )
                         {
                           // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:971:61: ^(
-                          // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] $postfixedExpression arguments )
+                          // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"]
+                          // $postfixedExpression arguments )
                           {
                             CommonTree root_1 = (CommonTree) adaptor.nil();
                             root_1 =
@@ -17720,13 +18511,17 @@ public class JavaParser extends Parser {
                     }
                     break;
                   case 4:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:17: ( SUPER innerDot= DOT
-                    // IDENT -> ^( $innerDot ^( $outerDot $postfixedExpression SUPER ) IDENT ) ) ( arguments -> ^(
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:17: ( SUPER
+                    // innerDot= DOT
+                    // IDENT -> ^( $innerDot ^( $outerDot $postfixedExpression SUPER ) IDENT ) ) (
+                    // arguments -> ^(
                     // METHOD_CALL $postfixedExpression arguments ) )?
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:17: ( SUPER innerDot= DOT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:17: ( SUPER
+                      // innerDot= DOT
                       // IDENT -> ^( $innerDot ^( $outerDot $postfixedExpression SUPER ) IDENT ) )
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:21: SUPER innerDot= DOT IDENT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:21: SUPER
+                      // innerDot= DOT IDENT
                       {
                         SUPER453 =
                             (Token) match(input, SUPER, FOLLOW_SUPER_in_postfixedExpression12325);
@@ -17761,9 +18556,11 @@ public class JavaParser extends Parser {
                                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
                           root_0 = (CommonTree) adaptor.nil();
-                          // 972:53: -> ^( $innerDot ^( $outerDot $postfixedExpression SUPER ) IDENT )
+                          // 972:53: -> ^( $innerDot ^( $outerDot $postfixedExpression SUPER ) IDENT
+                          // )
                           {
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:57: ^( $innerDot ^
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:57: ^(
+                            // $innerDot ^
                             // ( $outerDot $postfixedExpression SUPER ) IDENT )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -17771,7 +18568,8 @@ public class JavaParser extends Parser {
                                   (CommonTree)
                                       adaptor.becomeRoot(stream_innerDot.nextNode(), root_1);
 
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:69: ^(
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:972:69:
+                              // ^(
                               // $outerDot $postfixedExpression SUPER )
                               {
                                 CommonTree root_2 = (CommonTree) adaptor.nil();
@@ -17794,7 +18592,8 @@ public class JavaParser extends Parser {
                         }
                       }
 
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:974:17: ( arguments -> ^(
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:974:17: (
+                      // arguments -> ^(
                       // METHOD_CALL $postfixedExpression arguments ) )?
                       int alt130 = 2;
                       int LA130_0 = input.LA(1);
@@ -17804,7 +18603,8 @@ public class JavaParser extends Parser {
                       }
                       switch (alt130) {
                         case 1:
-                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:974:21: arguments
+                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:974:21:
+                          // arguments
                           {
                             pushFollow(FOLLOW_arguments_in_postfixedExpression12398);
                             arguments455 = arguments();
@@ -17830,7 +18630,8 @@ public class JavaParser extends Parser {
                               root_0 = (CommonTree) adaptor.nil();
                               // 974:53: -> ^( METHOD_CALL $postfixedExpression arguments )
                               {
-                                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:974:57: ^(
+                                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:974:57:
+                                // ^(
                                 // METHOD_CALL $postfixedExpression arguments )
                                 {
                                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -17856,7 +18657,8 @@ public class JavaParser extends Parser {
                     }
                     break;
                   case 5:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:976:17: innerNewExpression
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:976:17:
+                    // innerNewExpression
                     {
                       pushFollow(FOLLOW_innerNewExpression_in_postfixedExpression12469);
                       innerNewExpression456 = innerNewExpression();
@@ -17882,7 +18684,8 @@ public class JavaParser extends Parser {
                         root_0 = (CommonTree) adaptor.nil();
                         // 976:53: -> ^( DOT $postfixedExpression innerNewExpression )
                         {
-                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:976:57: ^( DOT
+                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:976:57: ^(
+                          // DOT
                           // $postfixedExpression innerNewExpression )
                           {
                             CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -17903,7 +18706,8 @@ public class JavaParser extends Parser {
               }
               break;
             case 2:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:978:13: LBRACK expression RBRACK
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:978:13: LBRACK expression
+              // RBRACK
               {
                 LBRACK457 = (Token) match(input, LBRACK, FOLLOW_LBRACK_in_postfixedExpression12526);
                 if (state.failed) return retval;
@@ -17935,7 +18739,8 @@ public class JavaParser extends Parser {
                   root_0 = (CommonTree) adaptor.nil();
                   // 978:53: -> ^( ARRAY_ELEMENT_ACCESS $postfixedExpression expression )
                   {
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:978:57: ^( ARRAY_ELEMENT_ACCESS
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:978:57: ^(
+                    // ARRAY_ELEMENT_ACCESS
                     // $postfixedExpression expression )
                     {
                       CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -17963,8 +18768,10 @@ public class JavaParser extends Parser {
           }
         } while (true);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:981:9: ( INC -> ^( POST_INC[$INC,
-        // \"POST_INC\"] $postfixedExpression) | DEC -> ^( POST_DEC[$DEC, \"POST_DEC\"] $postfixedExpression) )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:981:9: ( INC -> ^(
+        // POST_INC[$INC,
+        // \"POST_INC\"] $postfixedExpression) | DEC -> ^( POST_DEC[$DEC, \"POST_DEC\"]
+        // $postfixedExpression) )?
         int alt133 = 3;
         int LA133_0 = input.LA(1);
 
@@ -17997,7 +18804,8 @@ public class JavaParser extends Parser {
                 root_0 = (CommonTree) adaptor.nil();
                 // 981:17: -> ^( POST_INC[$INC, \"POST_INC\"] $postfixedExpression)
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:981:20: ^( POST_INC[$INC,
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:981:20: ^(
+                  // POST_INC[$INC,
                   // \"POST_INC\"] $postfixedExpression)
                   {
                     CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -18039,7 +18847,8 @@ public class JavaParser extends Parser {
                 root_0 = (CommonTree) adaptor.nil();
                 // 982:17: -> ^( POST_DEC[$DEC, \"POST_DEC\"] $postfixedExpression)
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:982:20: ^( POST_DEC[$DEC,
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:982:20: ^(
+                  // POST_DEC[$DEC,
                   // \"POST_DEC\"] $postfixedExpression)
                   {
                     CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -18091,15 +18900,24 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "primaryExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:986:1: primaryExpression : ( parenthesizedExpression | literal |
-  // newExpression | qualifiedIdentExpression | genericTypeArgumentListSimplified ( SUPER ( arguments -> ^(
-  // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) | DOT IDENT arguments ->
-  // ^( METHOD_CALL ^( DOT SUPER IDENT ) genericTypeArgumentListSimplified arguments ) ) | IDENT arguments -> ^( METHOD_CALL IDENT
-  // genericTypeArgumentListSimplified arguments ) | THIS arguments -> ^( THIS_CONSTRUCTOR_CALL[$THIS,
-  // \"THIS_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) ) | ( THIS -> THIS ) ( arguments -> ^(
-  // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] arguments ) )? | SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$SUPER,
-  // \"SUPER_CONSTRUCTOR_CALL\"] arguments ) | ( SUPER DOT IDENT ) ( arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT ) arguments ) | ->
-  // ^( DOT SUPER IDENT ) ) | ( primitiveType -> primitiveType ) ( arrayDeclarator -> ^( arrayDeclarator $primaryExpression) )* DOT
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:986:1: primaryExpression : (
+  // parenthesizedExpression | literal |
+  // newExpression | qualifiedIdentExpression | genericTypeArgumentListSimplified ( SUPER (
+  // arguments -> ^(
+  // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified
+  // arguments ) | DOT IDENT arguments ->
+  // ^( METHOD_CALL ^( DOT SUPER IDENT ) genericTypeArgumentListSimplified arguments ) ) | IDENT
+  // arguments -> ^( METHOD_CALL IDENT
+  // genericTypeArgumentListSimplified arguments ) | THIS arguments -> ^(
+  // THIS_CONSTRUCTOR_CALL[$THIS,
+  // \"THIS_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) ) | ( THIS -> THIS ) (
+  // arguments -> ^(
+  // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] arguments ) )? | SUPER arguments -> ^(
+  // SUPER_CONSTRUCTOR_CALL[$SUPER,
+  // \"SUPER_CONSTRUCTOR_CALL\"] arguments ) | ( SUPER DOT IDENT ) ( arguments -> ^( METHOD_CALL ^(
+  // DOT SUPER IDENT ) arguments ) | ->
+  // ^( DOT SUPER IDENT ) ) | ( primitiveType -> primitiveType ) ( arrayDeclarator -> ^(
+  // arrayDeclarator $primaryExpression) )* DOT
   // CLASS -> ^( DOT $primaryExpression CLASS ) | VOID DOT CLASS -> ^( DOT VOID CLASS ) );
   public final JavaParser.primaryExpression_return primaryExpression() throws RecognitionException {
     JavaParser.primaryExpression_return retval = new JavaParser.primaryExpression_return();
@@ -18183,22 +19001,33 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 105)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:987:5: ( parenthesizedExpression | literal | newExpression
-      // | qualifiedIdentExpression | genericTypeArgumentListSimplified ( SUPER ( arguments -> ^( SUPER_CONSTRUCTOR_CALL[$SUPER,
-      // \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) | DOT IDENT arguments -> ^( METHOD_CALL ^( DOT
-      // SUPER IDENT ) genericTypeArgumentListSimplified arguments ) ) | IDENT arguments -> ^( METHOD_CALL IDENT
-      // genericTypeArgumentListSimplified arguments ) | THIS arguments -> ^( THIS_CONSTRUCTOR_CALL[$THIS,
-      // \"THIS_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) ) | ( THIS -> THIS ) ( arguments -> ^(
-      // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] arguments ) )? | SUPER arguments -> ^(
-      // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] arguments ) | ( SUPER DOT IDENT ) ( arguments -> ^( METHOD_CALL
-      // ^( DOT SUPER IDENT ) arguments ) | -> ^( DOT SUPER IDENT ) ) | ( primitiveType -> primitiveType ) ( arrayDeclarator -> ^(
-      // arrayDeclarator $primaryExpression) )* DOT CLASS -> ^( DOT $primaryExpression CLASS ) | VOID DOT CLASS -> ^( DOT VOID
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:987:5: ( parenthesizedExpression
+      // | literal | newExpression
+      // | qualifiedIdentExpression | genericTypeArgumentListSimplified ( SUPER ( arguments -> ^(
+      // SUPER_CONSTRUCTOR_CALL[$SUPER,
+      // \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) | DOT IDENT
+      // arguments -> ^( METHOD_CALL ^( DOT
+      // SUPER IDENT ) genericTypeArgumentListSimplified arguments ) ) | IDENT arguments -> ^(
+      // METHOD_CALL IDENT
+      // genericTypeArgumentListSimplified arguments ) | THIS arguments -> ^(
+      // THIS_CONSTRUCTOR_CALL[$THIS,
+      // \"THIS_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) ) | ( THIS -> THIS
+      // ) ( arguments -> ^(
+      // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] arguments ) )? | SUPER arguments ->
+      // ^(
+      // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] arguments ) | ( SUPER DOT IDENT
+      // ) ( arguments -> ^( METHOD_CALL
+      // ^( DOT SUPER IDENT ) arguments ) | -> ^( DOT SUPER IDENT ) ) | ( primitiveType ->
+      // primitiveType ) ( arrayDeclarator -> ^(
+      // arrayDeclarator $primaryExpression) )* DOT CLASS -> ^( DOT $primaryExpression CLASS ) |
+      // VOID DOT CLASS -> ^( DOT VOID
       // CLASS ) )
       int alt139 = 10;
       alt139 = dfa139.predict(input);
       switch (alt139) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:987:9: parenthesizedExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:987:9:
+          // parenthesizedExpression
           {
             root_0 = (CommonTree) adaptor.nil();
 
@@ -18238,7 +19067,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:990:9: qualifiedIdentExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:990:9:
+          // qualifiedIdentExpression
           {
             root_0 = (CommonTree) adaptor.nil();
 
@@ -18252,11 +19082,16 @@ public class JavaParser extends Parser {
           }
           break;
         case 5:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:991:9: genericTypeArgumentListSimplified ( SUPER (
-          // arguments -> ^( SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified
-          // arguments ) | DOT IDENT arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT ) genericTypeArgumentListSimplified
-          // arguments ) ) | IDENT arguments -> ^( METHOD_CALL IDENT genericTypeArgumentListSimplified arguments ) | THIS
-          // arguments -> ^( THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:991:9:
+          // genericTypeArgumentListSimplified ( SUPER (
+          // arguments -> ^( SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"]
+          // genericTypeArgumentListSimplified
+          // arguments ) | DOT IDENT arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT )
+          // genericTypeArgumentListSimplified
+          // arguments ) ) | IDENT arguments -> ^( METHOD_CALL IDENT
+          // genericTypeArgumentListSimplified arguments ) | THIS
+          // arguments -> ^( THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"]
+          // genericTypeArgumentListSimplified
           // arguments ) )
           {
             pushFollow(FOLLOW_genericTypeArgumentListSimplified_in_primaryExpression12703);
@@ -18267,11 +19102,16 @@ public class JavaParser extends Parser {
             if (state.backtracking == 0)
               stream_genericTypeArgumentListSimplified.add(
                   genericTypeArgumentListSimplified466.getTree());
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:992:9: ( SUPER ( arguments -> ^(
-            // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) | DOT
-            // IDENT arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT ) genericTypeArgumentListSimplified arguments ) ) | IDENT
-            // arguments -> ^( METHOD_CALL IDENT genericTypeArgumentListSimplified arguments ) | THIS arguments -> ^(
-            // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:992:9: ( SUPER ( arguments
+            // -> ^(
+            // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"]
+            // genericTypeArgumentListSimplified arguments ) | DOT
+            // IDENT arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT )
+            // genericTypeArgumentListSimplified arguments ) ) | IDENT
+            // arguments -> ^( METHOD_CALL IDENT genericTypeArgumentListSimplified arguments ) |
+            // THIS arguments -> ^(
+            // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"]
+            // genericTypeArgumentListSimplified arguments ) )
             int alt135 = 3;
             switch (input.LA(1)) {
               case SUPER:
@@ -18301,17 +19141,23 @@ public class JavaParser extends Parser {
 
             switch (alt135) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:992:13: SUPER ( arguments -> ^(
-                // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) |
-                // DOT IDENT arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT ) genericTypeArgumentListSimplified arguments ) )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:992:13: SUPER (
+                // arguments -> ^(
+                // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"]
+                // genericTypeArgumentListSimplified arguments ) |
+                // DOT IDENT arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT )
+                // genericTypeArgumentListSimplified arguments ) )
                 {
                   SUPER467 = (Token) match(input, SUPER, FOLLOW_SUPER_in_primaryExpression12718);
                   if (state.failed) return retval;
                   if (state.backtracking == 0) stream_SUPER.add(SUPER467);
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:993:13: ( arguments -> ^(
-                  // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments ) |
-                  // DOT IDENT arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT ) genericTypeArgumentListSimplified arguments ) )
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:993:13: ( arguments
+                  // -> ^(
+                  // SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"]
+                  // genericTypeArgumentListSimplified arguments ) |
+                  // DOT IDENT arguments -> ^( METHOD_CALL ^( DOT SUPER IDENT )
+                  // genericTypeArgumentListSimplified arguments ) )
                   int alt134 = 2;
                   int LA134_0 = input.LA(1);
 
@@ -18354,11 +19200,13 @@ public class JavaParser extends Parser {
 
                           root_0 = (CommonTree) adaptor.nil();
                           // 993:57: -> ^( SUPER_CONSTRUCTOR_CALL[$SUPER,
-                          // \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments )
+                          // \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments
+                          // )
                           {
                             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:993:61: ^(
                             // SUPER_CONSTRUCTOR_CALL[$SUPER,
-                            // \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments )
+                            // \"SUPER_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified
+                            // arguments )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
                               root_1 =
@@ -18384,7 +19232,8 @@ public class JavaParser extends Parser {
                       }
                       break;
                     case 2:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:994:17: DOT IDENT arguments
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:994:17: DOT IDENT
+                      // arguments
                       {
                         DOT469 = (Token) match(input, DOT, FOLLOW_DOT_in_primaryExpression12796);
                         if (state.failed) return retval;
@@ -18416,9 +19265,11 @@ public class JavaParser extends Parser {
                                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
                           root_0 = (CommonTree) adaptor.nil();
-                          // 994:57: -> ^( METHOD_CALL ^( DOT SUPER IDENT ) genericTypeArgumentListSimplified arguments )
+                          // 994:57: -> ^( METHOD_CALL ^( DOT SUPER IDENT )
+                          // genericTypeArgumentListSimplified arguments )
                           {
-                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:994:61: ^( METHOD_CALL ^(
+                            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:994:61: ^(
+                            // METHOD_CALL ^(
                             // DOT SUPER IDENT ) genericTypeArgumentListSimplified arguments )
                             {
                               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -18428,7 +19279,8 @@ public class JavaParser extends Parser {
                                           (CommonTree) adaptor.create(METHOD_CALL, "METHOD_CALL"),
                                           root_1);
 
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:994:75: ^( DOT SUPER
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:994:75:
+                              // ^( DOT SUPER
                               // IDENT )
                               {
                                 CommonTree root_2 = (CommonTree) adaptor.nil();
@@ -18485,7 +19337,8 @@ public class JavaParser extends Parser {
                     root_0 = (CommonTree) adaptor.nil();
                     // 996:57: -> ^( METHOD_CALL IDENT genericTypeArgumentListSimplified arguments )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:996:61: ^( METHOD_CALL IDENT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:996:61: ^(
+                      // METHOD_CALL IDENT
                       // genericTypeArgumentListSimplified arguments )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -18540,7 +19393,8 @@ public class JavaParser extends Parser {
                     // \"THIS_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments )
                     {
                       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:997:61: ^(
-                      // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] genericTypeArgumentListSimplified arguments )
+                      // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"]
+                      // genericTypeArgumentListSimplified arguments )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
                         root_1 =
@@ -18569,7 +19423,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 6:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:999:9: ( THIS -> THIS ) ( arguments -> ^(
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:999:9: ( THIS -> THIS ) (
+          // arguments -> ^(
           // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] arguments ) )?
           {
             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:999:9: ( THIS -> THIS )
@@ -18635,7 +19490,8 @@ public class JavaParser extends Parser {
                             adaptor, "rule retval", retval != null ? retval.tree : null);
 
                     root_0 = (CommonTree) adaptor.nil();
-                    // 1001:57: -> ^( THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] arguments )
+                    // 1001:57: -> ^( THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"]
+                    // arguments )
                     {
                       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1001:61: ^(
                       // THIS_CONSTRUCTOR_CALL[$THIS, \"THIS_CONSTRUCTOR_CALL\"] arguments )
@@ -18692,9 +19548,11 @@ public class JavaParser extends Parser {
                       adaptor, "rule retval", retval != null ? retval.tree : null);
 
               root_0 = (CommonTree) adaptor.nil();
-              // 1003:57: -> ^( SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] arguments )
+              // 1003:57: -> ^( SUPER_CONSTRUCTOR_CALL[$SUPER, \"SUPER_CONSTRUCTOR_CALL\"] arguments
+              // )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1003:61: ^( SUPER_CONSTRUCTOR_CALL[$SUPER,
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1003:61: ^(
+                // SUPER_CONSTRUCTOR_CALL[$SUPER,
                 // \"SUPER_CONSTRUCTOR_CALL\"] arguments )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -18717,7 +19575,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 8:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1004:9: ( SUPER DOT IDENT ) ( arguments -> ^(
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1004:9: ( SUPER DOT IDENT ) (
+          // arguments -> ^(
           // METHOD_CALL ^( DOT SUPER IDENT ) arguments ) | -> ^( DOT SUPER IDENT ) )
           {
             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1004:9: ( SUPER DOT IDENT )
@@ -18736,7 +19595,8 @@ public class JavaParser extends Parser {
               if (state.backtracking == 0) stream_IDENT.add(IDENT482);
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1006:9: ( arguments -> ^( METHOD_CALL ^( DOT SUPER
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1006:9: ( arguments -> ^(
+            // METHOD_CALL ^( DOT SUPER
             // IDENT ) arguments ) | -> ^( DOT SUPER IDENT ) )
             int alt137 = 2;
             int LA137_0 = input.LA(1);
@@ -18789,7 +19649,8 @@ public class JavaParser extends Parser {
                     root_0 = (CommonTree) adaptor.nil();
                     // 1006:57: -> ^( METHOD_CALL ^( DOT SUPER IDENT ) arguments )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1006:61: ^( METHOD_CALL ^( DOT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1006:61: ^(
+                      // METHOD_CALL ^( DOT
                       // SUPER IDENT ) arguments )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -18799,7 +19660,8 @@ public class JavaParser extends Parser {
                                     (CommonTree) adaptor.create(METHOD_CALL, "METHOD_CALL"),
                                     root_1);
 
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1006:75: ^( DOT SUPER IDENT )
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1006:75: ^( DOT
+                        // SUPER IDENT )
                         {
                           CommonTree root_2 = (CommonTree) adaptor.nil();
                           root_2 = (CommonTree) adaptor.becomeRoot(stream_DOT.nextNode(), root_2);
@@ -18839,7 +19701,8 @@ public class JavaParser extends Parser {
                     root_0 = (CommonTree) adaptor.nil();
                     // 1007:57: -> ^( DOT SUPER IDENT )
                     {
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1007:61: ^( DOT SUPER IDENT )
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1007:61: ^( DOT
+                      // SUPER IDENT )
                       {
                         CommonTree root_1 = (CommonTree) adaptor.nil();
                         root_1 = (CommonTree) adaptor.becomeRoot(stream_DOT.nextNode(), root_1);
@@ -18859,10 +19722,12 @@ public class JavaParser extends Parser {
           }
           break;
         case 9:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1009:9: ( primitiveType -> primitiveType ) (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1009:9: ( primitiveType ->
+          // primitiveType ) (
           // arrayDeclarator -> ^( arrayDeclarator $primaryExpression) )* DOT CLASS
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1009:9: ( primitiveType -> primitiveType )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1009:9: ( primitiveType ->
+            // primitiveType )
             // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1009:13: primitiveType
             {
               pushFollow(FOLLOW_primitiveType_in_primaryExpression13352);
@@ -18895,7 +19760,8 @@ public class JavaParser extends Parser {
               }
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1011:9: ( arrayDeclarator -> ^( arrayDeclarator
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1011:9: ( arrayDeclarator
+            // -> ^( arrayDeclarator
             // $primaryExpression) )*
             loop138:
             do {
@@ -18908,7 +19774,8 @@ public class JavaParser extends Parser {
 
               switch (alt138) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1011:13: arrayDeclarator
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1011:13:
+                  // arrayDeclarator
                   {
                     pushFollow(FOLLOW_arrayDeclarator_in_primaryExpression13411);
                     arrayDeclarator485 = arrayDeclarator();
@@ -18934,7 +19801,8 @@ public class JavaParser extends Parser {
                       root_0 = (CommonTree) adaptor.nil();
                       // 1011:57: -> ^( arrayDeclarator $primaryExpression)
                       {
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1011:61: ^( arrayDeclarator
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1011:61: ^(
+                        // arrayDeclarator
                         // $primaryExpression)
                         {
                           CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -18982,7 +19850,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 1013:57: -> ^( DOT $primaryExpression CLASS )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1013:61: ^( DOT $primaryExpression CLASS )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1013:61: ^( DOT
+                // $primaryExpression CLASS )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_DOT.nextNode(), root_1);
@@ -19029,7 +19898,8 @@ public class JavaParser extends Parser {
               root_0 = (CommonTree) adaptor.nil();
               // 1014:57: -> ^( DOT VOID CLASS )
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1014:61: ^( DOT VOID CLASS )
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1014:61: ^( DOT VOID
+                // CLASS )
                 {
                   CommonTree root_1 = (CommonTree) adaptor.nil();
                   root_1 = (CommonTree) adaptor.becomeRoot(stream_DOT.nextNode(), root_1);
@@ -19076,15 +19946,24 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "qualifiedIdentExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1017:1: qualifiedIdentExpression : ( qualifiedIdentifier ->
-  // qualifiedIdentifier ) ( ( arrayDeclarator -> ^( arrayDeclarator $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT
-  // $qualifiedIdentExpression CLASS ) ) | arguments -> ^( METHOD_CALL qualifiedIdentifier arguments ) | outerDot= DOT ( CLASS -> ^(
-  // DOT qualifiedIdentifier CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-  // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments ) | SUPER innerDot= DOT IDENT
-  // arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT ) genericTypeArgumentListSimplified
-  // arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT ) genericTypeArgumentListSimplified arguments ) )
-  // | THIS -> ^( DOT qualifiedIdentifier THIS ) | Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-  // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments ) | innerNewExpression -> ^( DOT qualifiedIdentifier innerNewExpression
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1017:1: qualifiedIdentExpression : (
+  // qualifiedIdentifier ->
+  // qualifiedIdentifier ) ( ( arrayDeclarator -> ^( arrayDeclarator $qualifiedIdentExpression) )+ (
+  // DOT CLASS -> ^( DOT
+  // $qualifiedIdentExpression CLASS ) ) | arguments -> ^( METHOD_CALL qualifiedIdentifier arguments
+  // ) | outerDot= DOT ( CLASS -> ^(
+  // DOT qualifiedIdentifier CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments ->
+  // ^( SUPER_CONSTRUCTOR_CALL[$Super,
+  // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments ) |
+  // SUPER innerDot= DOT IDENT
+  // arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
+  // genericTypeArgumentListSimplified
+  // arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT )
+  // genericTypeArgumentListSimplified arguments ) )
+  // | THIS -> ^( DOT qualifiedIdentifier THIS ) | Super= SUPER arguments -> ^(
+  // SUPER_CONSTRUCTOR_CALL[$Super,
+  // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments ) | innerNewExpression -> ^( DOT
+  // qualifiedIdentifier innerNewExpression
   // ) ) )? ;
   public final JavaParser.qualifiedIdentExpression_return qualifiedIdentExpression()
       throws RecognitionException {
@@ -19151,28 +20030,46 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 106)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1019:5: ( ( qualifiedIdentifier -> qualifiedIdentifier ) (
-      // ( arrayDeclarator -> ^( arrayDeclarator $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT $qualifiedIdentExpression
-      // CLASS ) ) | arguments -> ^( METHOD_CALL qualifiedIdentifier arguments ) | outerDot= DOT ( CLASS -> ^( DOT
-      // qualifiedIdentifier CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments -> ^(
-      // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments
-      // ) | SUPER innerDot= DOT IDENT arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
-      // genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT )
-      // genericTypeArgumentListSimplified arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS ) | Super= SUPER arguments -> ^(
-      // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments ) | innerNewExpression -> ^( DOT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1019:5: ( ( qualifiedIdentifier
+      // -> qualifiedIdentifier ) (
+      // ( arrayDeclarator -> ^( arrayDeclarator $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT
+      // $qualifiedIdentExpression
+      // CLASS ) ) | arguments -> ^( METHOD_CALL qualifiedIdentifier arguments ) | outerDot= DOT (
+      // CLASS -> ^( DOT
+      // qualifiedIdentifier CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments ->
+      // ^(
+      // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
+      // genericTypeArgumentListSimplified arguments
+      // ) | SUPER innerDot= DOT IDENT arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot
+      // qualifiedIdentifier SUPER ) IDENT )
+      // genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT
+      // qualifiedIdentifier IDENT )
+      // genericTypeArgumentListSimplified arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS )
+      // | Super= SUPER arguments -> ^(
+      // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments )
+      // | innerNewExpression -> ^( DOT
       // qualifiedIdentifier innerNewExpression ) ) )? )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1019:9: ( qualifiedIdentifier -> qualifiedIdentifier ) ( (
-      // arrayDeclarator -> ^( arrayDeclarator $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT $qualifiedIdentExpression CLASS
-      // ) ) | arguments -> ^( METHOD_CALL qualifiedIdentifier arguments ) | outerDot= DOT ( CLASS -> ^( DOT qualifiedIdentifier
-      // CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-      // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments ) | SUPER innerDot= DOT IDENT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1019:9: ( qualifiedIdentifier ->
+      // qualifiedIdentifier ) ( (
+      // arrayDeclarator -> ^( arrayDeclarator $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT
+      // $qualifiedIdentExpression CLASS
+      // ) ) | arguments -> ^( METHOD_CALL qualifiedIdentifier arguments ) | outerDot= DOT ( CLASS
+      // -> ^( DOT qualifiedIdentifier
+      // CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments -> ^(
+      // SUPER_CONSTRUCTOR_CALL[$Super,
+      // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments
+      // ) | SUPER innerDot= DOT IDENT
       // arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
-      // genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT )
-      // genericTypeArgumentListSimplified arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS ) | Super= SUPER arguments -> ^(
-      // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments ) | innerNewExpression -> ^( DOT
+      // genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT
+      // qualifiedIdentifier IDENT )
+      // genericTypeArgumentListSimplified arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS )
+      // | Super= SUPER arguments -> ^(
+      // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments )
+      // | innerNewExpression -> ^( DOT
       // qualifiedIdentifier innerNewExpression ) ) )?
       {
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1019:9: ( qualifiedIdentifier -> qualifiedIdentifier )
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1019:9: ( qualifiedIdentifier
+        // -> qualifiedIdentifier )
         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1019:13: qualifiedIdentifier
         {
           pushFollow(FOLLOW_qualifiedIdentifier_in_qualifiedIdentExpression13620);
@@ -19206,24 +20103,36 @@ public class JavaParser extends Parser {
           }
         }
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:9: ( ( arrayDeclarator -> ^( arrayDeclarator
-        // $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT $qualifiedIdentExpression CLASS ) ) | arguments -> ^( METHOD_CALL
-        // qualifiedIdentifier arguments ) | outerDot= DOT ( CLASS -> ^( DOT qualifiedIdentifier CLASS ) |
-        // genericTypeArgumentListSimplified (Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-        // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments ) | SUPER innerDot= DOT
-        // IDENT arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
-        // genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT )
-        // genericTypeArgumentListSimplified arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS ) | Super= SUPER arguments
-        // -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments ) | innerNewExpression
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:9: ( ( arrayDeclarator ->
+        // ^( arrayDeclarator
+        // $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT $qualifiedIdentExpression CLASS ) ) |
+        // arguments -> ^( METHOD_CALL
+        // qualifiedIdentifier arguments ) | outerDot= DOT ( CLASS -> ^( DOT qualifiedIdentifier
+        // CLASS ) |
+        // genericTypeArgumentListSimplified (Super= SUPER arguments -> ^(
+        // SUPER_CONSTRUCTOR_CALL[$Super,
+        // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified
+        // arguments ) | SUPER innerDot= DOT
+        // IDENT arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER )
+        // IDENT )
+        // genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT
+        // qualifiedIdentifier IDENT )
+        // genericTypeArgumentListSimplified arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS
+        // ) | Super= SUPER arguments
+        // -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
+        // arguments ) | innerNewExpression
         // -> ^( DOT qualifiedIdentifier innerNewExpression ) ) )?
         int alt143 = 4;
         alt143 = dfa143.predict(input);
         switch (alt143) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: ( arrayDeclarator -> ^(
-            // arrayDeclarator $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT $qualifiedIdentExpression CLASS ) )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: ( arrayDeclarator
+            // -> ^(
+            // arrayDeclarator $qualifiedIdentExpression) )+ ( DOT CLASS -> ^( DOT
+            // $qualifiedIdentExpression CLASS ) )
             {
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: ( arrayDeclarator -> ^(
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: (
+              // arrayDeclarator -> ^(
               // arrayDeclarator $qualifiedIdentExpression) )+
               int cnt140 = 0;
               loop140:
@@ -19237,7 +20146,8 @@ public class JavaParser extends Parser {
 
                 switch (alt140) {
                   case 1:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:17: arrayDeclarator
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:17:
+                    // arrayDeclarator
                     {
                       pushFollow(FOLLOW_arrayDeclarator_in_qualifiedIdentExpression13690);
                       arrayDeclarator492 = arrayDeclarator();
@@ -19294,7 +20204,8 @@ public class JavaParser extends Parser {
                 cnt140++;
               } while (true);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1024:13: ( DOT CLASS -> ^( DOT
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1024:13: ( DOT CLASS ->
+              // ^( DOT
               // $qualifiedIdentExpression CLASS ) )
               // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1024:17: DOT CLASS
               {
@@ -19367,7 +20278,8 @@ public class JavaParser extends Parser {
                 root_0 = (CommonTree) adaptor.nil();
                 // 1026:57: -> ^( METHOD_CALL qualifiedIdentifier arguments )
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1026:61: ^( METHOD_CALL
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1026:61: ^(
+                  // METHOD_CALL
                   // qualifiedIdentifier arguments )
                   {
                     CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -19388,27 +20300,41 @@ public class JavaParser extends Parser {
             }
             break;
           case 3:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1027:13: outerDot= DOT ( CLASS -> ^( DOT
-            // qualifiedIdentifier CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments -> ^(
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1027:13: outerDot= DOT (
+            // CLASS -> ^( DOT
+            // qualifiedIdentifier CLASS ) | genericTypeArgumentListSimplified (Super= SUPER
+            // arguments -> ^(
             // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
-            // genericTypeArgumentListSimplified arguments ) | SUPER innerDot= DOT IDENT arguments -> ^( METHOD_CALL ^(
-            // $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT ) genericTypeArgumentListSimplified arguments ) |
-            // IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT ) genericTypeArgumentListSimplified
-            // arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS ) | Super= SUPER arguments -> ^(
-            // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments ) |
+            // genericTypeArgumentListSimplified arguments ) | SUPER innerDot= DOT IDENT arguments
+            // -> ^( METHOD_CALL ^(
+            // $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
+            // genericTypeArgumentListSimplified arguments ) |
+            // IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT )
+            // genericTypeArgumentListSimplified
+            // arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS ) | Super= SUPER arguments ->
+            // ^(
+            // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
+            // arguments ) |
             // innerNewExpression -> ^( DOT qualifiedIdentifier innerNewExpression ) )
             {
               outerDot = (Token) match(input, DOT, FOLLOW_DOT_in_qualifiedIdentExpression13891);
               if (state.failed) return retval;
               if (state.backtracking == 0) stream_DOT.add(outerDot);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1028:13: ( CLASS -> ^( DOT qualifiedIdentifier
-              // CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-              // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments ) | SUPER
-              // innerDot= DOT IDENT arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
-              // genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier
-              // IDENT ) genericTypeArgumentListSimplified arguments ) ) | THIS -> ^( DOT qualifiedIdentifier THIS ) | Super=
-              // SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1028:13: ( CLASS -> ^(
+              // DOT qualifiedIdentifier
+              // CLASS ) | genericTypeArgumentListSimplified (Super= SUPER arguments -> ^(
+              // SUPER_CONSTRUCTOR_CALL[$Super,
+              // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified
+              // arguments ) | SUPER
+              // innerDot= DOT IDENT arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot
+              // qualifiedIdentifier SUPER ) IDENT )
+              // genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL
+              // ^( DOT qualifiedIdentifier
+              // IDENT ) genericTypeArgumentListSimplified arguments ) ) | THIS -> ^( DOT
+              // qualifiedIdentifier THIS ) | Super=
+              // SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"]
+              // qualifiedIdentifier arguments
               // ) | innerNewExpression -> ^( DOT qualifiedIdentifier innerNewExpression ) )
               int alt142 = 5;
               switch (input.LA(1)) {
@@ -19491,10 +20417,14 @@ public class JavaParser extends Parser {
                   break;
                 case 2:
                   // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1029:17:
-                  // genericTypeArgumentListSimplified (Super= SUPER arguments -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-                  // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments ) | SUPER
-                  // innerDot= DOT IDENT arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER )
-                  // IDENT ) genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT
+                  // genericTypeArgumentListSimplified (Super= SUPER arguments -> ^(
+                  // SUPER_CONSTRUCTOR_CALL[$Super,
+                  // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
+                  // genericTypeArgumentListSimplified arguments ) | SUPER
+                  // innerDot= DOT IDENT arguments -> ^( METHOD_CALL ^( $innerDot ^( $outerDot
+                  // qualifiedIdentifier SUPER )
+                  // IDENT ) genericTypeArgumentListSimplified arguments ) | IDENT arguments -> ^(
+                  // METHOD_CALL ^( DOT
                   // qualifiedIdentifier IDENT ) genericTypeArgumentListSimplified arguments ) )
                   {
                     pushFollow(
@@ -19506,11 +20436,16 @@ public class JavaParser extends Parser {
                     if (state.backtracking == 0)
                       stream_genericTypeArgumentListSimplified.add(
                           genericTypeArgumentListSimplified497.getTree());
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:17: (Super= SUPER arguments -> ^(
-                    // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
-                    // genericTypeArgumentListSimplified arguments ) | SUPER innerDot= DOT IDENT arguments -> ^( METHOD_CALL
-                    // ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT ) genericTypeArgumentListSimplified
-                    // arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT )
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:17: (Super=
+                    // SUPER arguments -> ^(
+                    // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"]
+                    // qualifiedIdentifier
+                    // genericTypeArgumentListSimplified arguments ) | SUPER innerDot= DOT IDENT
+                    // arguments -> ^( METHOD_CALL
+                    // ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
+                    // genericTypeArgumentListSimplified
+                    // arguments ) | IDENT arguments -> ^( METHOD_CALL ^( DOT qualifiedIdentifier
+                    // IDENT )
                     // genericTypeArgumentListSimplified arguments ) )
                     int alt141 = 3;
                     int LA141_0 = input.LA(1);
@@ -19544,7 +20479,8 @@ public class JavaParser extends Parser {
                     }
                     switch (alt141) {
                       case 1:
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:21: Super= SUPER arguments
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:21: Super=
+                        // SUPER arguments
                         {
                           Super =
                               (Token)
@@ -19561,7 +20497,8 @@ public class JavaParser extends Parser {
                           if (state.backtracking == 0) stream_arguments.add(arguments498.getTree());
 
                           // AST REWRITE
-                          // elements: qualifiedIdentifier, arguments, genericTypeArgumentListSimplified
+                          // elements: qualifiedIdentifier, arguments,
+                          // genericTypeArgumentListSimplified
                           // token labels:
                           // rule labels: retval
                           // token list labels:
@@ -19575,10 +20512,13 @@ public class JavaParser extends Parser {
 
                             root_0 = (CommonTree) adaptor.nil();
                             // 1030:57: -> ^( SUPER_CONSTRUCTOR_CALL[$Super,
-                            // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier genericTypeArgumentListSimplified arguments )
+                            // \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
+                            // genericTypeArgumentListSimplified arguments )
                             {
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:61: ^(
-                              // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:61:
+                              // ^(
+                              // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"]
+                              // qualifiedIdentifier
                               // genericTypeArgumentListSimplified arguments )
                               {
                                 CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -19606,7 +20546,8 @@ public class JavaParser extends Parser {
                         }
                         break;
                       case 2:
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1031:21: SUPER innerDot= DOT
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1031:21: SUPER
+                        // innerDot= DOT
                         // IDENT arguments
                         {
                           SUPER499 =
@@ -19655,11 +20596,14 @@ public class JavaParser extends Parser {
                                     adaptor, "rule retval", retval != null ? retval.tree : null);
 
                             root_0 = (CommonTree) adaptor.nil();
-                            // 1031:57: -> ^( METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
+                            // 1031:57: -> ^( METHOD_CALL ^( $innerDot ^( $outerDot
+                            // qualifiedIdentifier SUPER ) IDENT )
                             // genericTypeArgumentListSimplified arguments )
                             {
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1031:61: ^(
-                              // METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER ) IDENT )
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1031:61:
+                              // ^(
+                              // METHOD_CALL ^( $innerDot ^( $outerDot qualifiedIdentifier SUPER )
+                              // IDENT )
                               // genericTypeArgumentListSimplified arguments )
                               {
                                 CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -19707,7 +20651,8 @@ public class JavaParser extends Parser {
                         }
                         break;
                       case 3:
-                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1032:21: IDENT arguments
+                        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1032:21: IDENT
+                        // arguments
                         {
                           IDENT502 =
                               (Token)
@@ -19724,7 +20669,8 @@ public class JavaParser extends Parser {
                           if (state.backtracking == 0) stream_arguments.add(arguments503.getTree());
 
                           // AST REWRITE
-                          // elements: arguments, qualifiedIdentifier, IDENT, genericTypeArgumentListSimplified, DOT
+                          // elements: arguments, qualifiedIdentifier, IDENT,
+                          // genericTypeArgumentListSimplified, DOT
                           // token labels:
                           // rule labels: retval
                           // token list labels:
@@ -19740,8 +20686,10 @@ public class JavaParser extends Parser {
                             // 1032:57: -> ^( METHOD_CALL ^( DOT qualifiedIdentifier IDENT )
                             // genericTypeArgumentListSimplified arguments )
                             {
-                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1032:61: ^(
-                              // METHOD_CALL ^( DOT qualifiedIdentifier IDENT ) genericTypeArgumentListSimplified
+                              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1032:61:
+                              // ^(
+                              // METHOD_CALL ^( DOT qualifiedIdentifier IDENT )
+                              // genericTypeArgumentListSimplified
                               // arguments )
                               {
                                 CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -19821,7 +20769,8 @@ public class JavaParser extends Parser {
                   }
                   break;
                 case 4:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1035:17: Super= SUPER arguments
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1035:17: Super= SUPER
+                  // arguments
                   {
                     Super =
                         (Token) match(input, SUPER, FOLLOW_SUPER_in_qualifiedIdentExpression14250);
@@ -19849,11 +20798,13 @@ public class JavaParser extends Parser {
                               adaptor, "rule retval", retval != null ? retval.tree : null);
 
                       root_0 = (CommonTree) adaptor.nil();
-                      // 1035:57: -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier
+                      // 1035:57: -> ^( SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"]
+                      // qualifiedIdentifier
                       // arguments )
                       {
                         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1035:61: ^(
-                        // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"] qualifiedIdentifier arguments )
+                        // SUPER_CONSTRUCTOR_CALL[$Super, \"SUPER_CONSTRUCTOR_CALL\"]
+                        // qualifiedIdentifier arguments )
                         {
                           CommonTree root_1 = (CommonTree) adaptor.nil();
                           root_1 =
@@ -19878,7 +20829,8 @@ public class JavaParser extends Parser {
                   }
                   break;
                 case 5:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1036:17: innerNewExpression
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1036:17:
+                  // innerNewExpression
                   {
                     pushFollow(FOLLOW_innerNewExpression_in_qualifiedIdentExpression14300);
                     innerNewExpression506 = innerNewExpression();
@@ -19957,11 +20909,16 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "newExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1041:1: newExpression : NEW ( primitiveType newArrayConstruction
-  // -> ^( STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction ) | (
-  // genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified ( newArrayConstruction -> ^( STATIC_ARRAY_CREATOR[$NEW,
-  // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified newArrayConstruction ) | arguments (
-  // classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1041:1: newExpression : NEW (
+  // primitiveType newArrayConstruction
+  // -> ^( STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction )
+  // | (
+  // genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified ( newArrayConstruction -> ^(
+  // STATIC_ARRAY_CREATOR[$NEW,
+  // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified
+  // newArrayConstruction ) | arguments (
+  // classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+  // genericTypeArgumentListSimplified )?
   // qualifiedTypeIdentSimplified arguments ( classBody )? ) ) ) ;
   public final JavaParser.newExpression_return newExpression() throws RecognitionException {
     JavaParser.newExpression_return retval = new JavaParser.newExpression_return();
@@ -20002,29 +20959,45 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 107)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1042:5: ( NEW ( primitiveType newArrayConstruction -> ^(
-      // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction ) | (
-      // genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified ( newArrayConstruction -> ^( STATIC_ARRAY_CREATOR[$NEW,
-      // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified newArrayConstruction ) |
-      // arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1042:5: ( NEW ( primitiveType
+      // newArrayConstruction -> ^(
+      // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction ) |
+      // (
+      // genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified ( newArrayConstruction ->
+      // ^( STATIC_ARRAY_CREATOR[$NEW,
+      // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+      // qualifiedTypeIdentSimplified newArrayConstruction ) |
+      // arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+      // genericTypeArgumentListSimplified
       // )? qualifiedTypeIdentSimplified arguments ( classBody )? ) ) ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1042:9: NEW ( primitiveType newArrayConstruction -> ^(
-      // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction ) | (
-      // genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified ( newArrayConstruction -> ^( STATIC_ARRAY_CREATOR[$NEW,
-      // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified newArrayConstruction ) |
-      // arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1042:9: NEW ( primitiveType
+      // newArrayConstruction -> ^(
+      // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction ) |
+      // (
+      // genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified ( newArrayConstruction ->
+      // ^( STATIC_ARRAY_CREATOR[$NEW,
+      // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+      // qualifiedTypeIdentSimplified newArrayConstruction ) |
+      // arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+      // genericTypeArgumentListSimplified
       // )? qualifiedTypeIdentSimplified arguments ( classBody )? ) ) )
       {
         NEW507 = (Token) match(input, NEW, FOLLOW_NEW_in_newExpression14376);
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_NEW.add(NEW507);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1043:9: ( primitiveType newArrayConstruction -> ^(
-        // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction ) | (
-        // genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified ( newArrayConstruction -> ^(
-        // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
-        // qualifiedTypeIdentSimplified newArrayConstruction ) | arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW,
-        // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified arguments ( classBody )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1043:9: ( primitiveType
+        // newArrayConstruction -> ^(
+        // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction )
+        // | (
+        // genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified ( newArrayConstruction
+        // -> ^(
+        // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified
+        // )?
+        // qualifiedTypeIdentSimplified newArrayConstruction ) | arguments ( classBody )? -> ^(
+        // CLASS_CONSTRUCTOR_CALL[$NEW,
+        // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+        // qualifiedTypeIdentSimplified arguments ( classBody )?
         // ) ) )
         int alt147 = 2;
         int LA147_0 = input.LA(1);
@@ -20050,7 +21023,8 @@ public class JavaParser extends Parser {
         }
         switch (alt147) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1043:13: primitiveType newArrayConstruction
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1043:13: primitiveType
+            // newArrayConstruction
             {
               pushFollow(FOLLOW_primitiveType_in_newExpression14392);
               primitiveType508 = primitiveType();
@@ -20080,9 +21054,11 @@ public class JavaParser extends Parser {
                         adaptor, "rule retval", retval != null ? retval.tree : null);
 
                 root_0 = (CommonTree) adaptor.nil();
-                // 1044:13: -> ^( STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction )
+                // 1044:13: -> ^( STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] primitiveType
+                // newArrayConstruction )
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1044:17: ^( STATIC_ARRAY_CREATOR[$NEW,
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1044:17: ^(
+                  // STATIC_ARRAY_CREATOR[$NEW,
                   // \"STATIC_ARRAY_CREATOR\"] primitiveType newArrayConstruction )
                   {
                     CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -20106,14 +21082,19 @@ public class JavaParser extends Parser {
             }
             break;
           case 2:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1045:13: ( genericTypeArgumentListSimplified )
-            // ? qualifiedTypeIdentSimplified ( newArrayConstruction -> ^( STATIC_ARRAY_CREATOR[$NEW,
-            // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1045:13: (
+            // genericTypeArgumentListSimplified )
+            // ? qualifiedTypeIdentSimplified ( newArrayConstruction -> ^(
+            // STATIC_ARRAY_CREATOR[$NEW,
+            // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+            // qualifiedTypeIdentSimplified
             // newArrayConstruction ) | arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW,
-            // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified arguments (
+            // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+            // qualifiedTypeIdentSimplified arguments (
             // classBody )? ) )
             {
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1045:13: ( genericTypeArgumentListSimplified )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1045:13: (
+              // genericTypeArgumentListSimplified )?
               int alt144 = 2;
               int LA144_0 = input.LA(1);
 
@@ -20122,7 +21103,8 @@ public class JavaParser extends Parser {
               }
               switch (alt144) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeArgumentListSimplified
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                  // genericTypeArgumentListSimplified
                   {
                     pushFollow(FOLLOW_genericTypeArgumentListSimplified_in_newExpression14438);
                     genericTypeArgumentListSimplified510 = genericTypeArgumentListSimplified();
@@ -20143,10 +21125,14 @@ public class JavaParser extends Parser {
               if (state.failed) return retval;
               if (state.backtracking == 0)
                 stream_qualifiedTypeIdentSimplified.add(qualifiedTypeIdentSimplified511.getTree());
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1046:13: ( newArrayConstruction -> ^(
-              // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
-              // qualifiedTypeIdentSimplified newArrayConstruction ) | arguments ( classBody )? -> ^(
-              // CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1046:13: (
+              // newArrayConstruction -> ^(
+              // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+              // genericTypeArgumentListSimplified )?
+              // qualifiedTypeIdentSimplified newArrayConstruction ) | arguments ( classBody )? ->
+              // ^(
+              // CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+              // genericTypeArgumentListSimplified )?
               // qualifiedTypeIdentSimplified arguments ( classBody )? ) )
               int alt146 = 2;
               int LA146_0 = input.LA(1);
@@ -20166,7 +21152,8 @@ public class JavaParser extends Parser {
               }
               switch (alt146) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1046:17: newArrayConstruction
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1046:17:
+                  // newArrayConstruction
                   {
                     pushFollow(FOLLOW_newArrayConstruction_in_newExpression14459);
                     newArrayConstruction512 = newArrayConstruction();
@@ -20177,7 +21164,8 @@ public class JavaParser extends Parser {
                       stream_newArrayConstruction.add(newArrayConstruction512.getTree());
 
                     // AST REWRITE
-                    // elements: newArrayConstruction, qualifiedTypeIdentSimplified, genericTypeArgumentListSimplified
+                    // elements: newArrayConstruction, qualifiedTypeIdentSimplified,
+                    // genericTypeArgumentListSimplified
                     // token labels:
                     // rule labels: retval
                     // token list labels:
@@ -20191,11 +21179,13 @@ public class JavaParser extends Parser {
 
                       root_0 = (CommonTree) adaptor.nil();
                       // 1047:17: -> ^( STATIC_ARRAY_CREATOR[$NEW,
-                      // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified
+                      // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+                      // qualifiedTypeIdentSimplified
                       // newArrayConstruction )
                       {
                         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1047:21: ^(
-                        // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+                        // STATIC_ARRAY_CREATOR[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+                        // genericTypeArgumentListSimplified )?
                         // qualifiedTypeIdentSimplified newArrayConstruction )
                         {
                           CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -20226,7 +21216,8 @@ public class JavaParser extends Parser {
                   }
                   break;
                 case 2:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1048:17: arguments ( classBody )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1048:17: arguments (
+                  // classBody )?
                   {
                     pushFollow(FOLLOW_arguments_in_newExpression14524);
                     arguments513 = arguments();
@@ -20234,7 +21225,8 @@ public class JavaParser extends Parser {
                     state._fsp--;
                     if (state.failed) return retval;
                     if (state.backtracking == 0) stream_arguments.add(arguments513.getTree());
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1048:27: ( classBody )?
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1048:27: (
+                    // classBody )?
                     int alt145 = 2;
                     int LA145_0 = input.LA(1);
 
@@ -20256,7 +21248,8 @@ public class JavaParser extends Parser {
                     }
 
                     // AST REWRITE
-                    // elements: genericTypeArgumentListSimplified, arguments, classBody, qualifiedTypeIdentSimplified
+                    // elements: genericTypeArgumentListSimplified, arguments, classBody,
+                    // qualifiedTypeIdentSimplified
                     // token labels:
                     // rule labels: retval
                     // token list labels:
@@ -20270,11 +21263,13 @@ public class JavaParser extends Parser {
 
                       root_0 = (CommonTree) adaptor.nil();
                       // 1049:17: -> ^( CLASS_CONSTRUCTOR_CALL[$NEW,
-                      // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? qualifiedTypeIdentSimplified
+                      // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+                      // qualifiedTypeIdentSimplified
                       // arguments ( classBody )? )
                       {
                         // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1049:21: ^(
-                        // CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )?
+                        // CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+                        // genericTypeArgumentListSimplified )?
                         // qualifiedTypeIdentSimplified arguments ( classBody )? )
                         {
                           CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -20297,7 +21292,8 @@ public class JavaParser extends Parser {
                           stream_genericTypeArgumentListSimplified.reset();
                           adaptor.addChild(root_1, stream_qualifiedTypeIdentSimplified.nextTree());
                           adaptor.addChild(root_1, stream_arguments.nextTree());
-                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1049:150: ( classBody )?
+                          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1049:150: (
+                          // classBody )?
                           if (stream_classBody.hasNext()) {
                             adaptor.addChild(root_1, stream_classBody.nextTree());
                           }
@@ -20348,8 +21344,10 @@ public class JavaParser extends Parser {
 
   // $ANTLR start "innerNewExpression"
   // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1054:1: innerNewExpression : NEW (
-  // genericTypeArgumentListSimplified )? IDENT arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW,
-  // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? IDENT arguments ( classBody )? ) ;
+  // genericTypeArgumentListSimplified )? IDENT arguments ( classBody )? -> ^(
+  // CLASS_CONSTRUCTOR_CALL[$NEW,
+  // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? IDENT arguments ( classBody )?
+  // ) ;
   public final JavaParser.innerNewExpression_return innerNewExpression()
       throws RecognitionException {
     JavaParser.innerNewExpression_return retval = new JavaParser.innerNewExpression_return();
@@ -20379,17 +21377,21 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 108)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1055:5: ( NEW ( genericTypeArgumentListSimplified )? IDENT
-      // arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1055:5: ( NEW (
+      // genericTypeArgumentListSimplified )? IDENT
+      // arguments ( classBody )? -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+      // genericTypeArgumentListSimplified
       // )? IDENT arguments ( classBody )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1055:9: NEW ( genericTypeArgumentListSimplified )? IDENT
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1055:9: NEW (
+      // genericTypeArgumentListSimplified )? IDENT
       // arguments ( classBody )?
       {
         NEW515 = (Token) match(input, NEW, FOLLOW_NEW_in_innerNewExpression14625);
         if (state.failed) return retval;
         if (state.backtracking == 0) stream_NEW.add(NEW515);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1055:13: ( genericTypeArgumentListSimplified )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1055:13: (
+        // genericTypeArgumentListSimplified )?
         int alt148 = 2;
         int LA148_0 = input.LA(1);
 
@@ -20398,7 +21400,8 @@ public class JavaParser extends Parser {
         }
         switch (alt148) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeArgumentListSimplified
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+            // genericTypeArgumentListSimplified
             {
               pushFollow(FOLLOW_genericTypeArgumentListSimplified_in_innerNewExpression14627);
               genericTypeArgumentListSimplified516 = genericTypeArgumentListSimplified();
@@ -20457,11 +21460,14 @@ public class JavaParser extends Parser {
                   adaptor, "rule retval", retval != null ? retval.tree : null);
 
           root_0 = (CommonTree) adaptor.nil();
-          // 1056:9: -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? IDENT
+          // 1056:9: -> ^( CLASS_CONSTRUCTOR_CALL[$NEW, \"STATIC_ARRAY_CREATOR\"] (
+          // genericTypeArgumentListSimplified )? IDENT
           // arguments ( classBody )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1056:13: ^( CLASS_CONSTRUCTOR_CALL[$NEW,
-            // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? IDENT arguments ( classBody )? )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1056:13: ^(
+            // CLASS_CONSTRUCTOR_CALL[$NEW,
+            // \"STATIC_ARRAY_CREATOR\"] ( genericTypeArgumentListSimplified )? IDENT arguments (
+            // classBody )? )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
               root_1 =
@@ -20524,8 +21530,10 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "newArrayConstruction"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1059:1: newArrayConstruction : ( arrayDeclaratorList
-  // arrayInitializer | LBRACK expression RBRACK ( LBRACK expression RBRACK )* ( arrayDeclaratorList )? );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1059:1: newArrayConstruction : (
+  // arrayDeclaratorList
+  // arrayInitializer | LBRACK expression RBRACK ( LBRACK expression RBRACK )* ( arrayDeclaratorList
+  // )? );
   public final JavaParser.newArrayConstruction_return newArrayConstruction()
       throws RecognitionException {
     JavaParser.newArrayConstruction_return retval = new JavaParser.newArrayConstruction_return();
@@ -20556,7 +21564,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 109)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1060:5: ( arrayDeclaratorList arrayInitializer | LBRACK
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1060:5: ( arrayDeclaratorList
+      // arrayInitializer | LBRACK
       // expression RBRACK ( LBRACK expression RBRACK )* ( arrayDeclaratorList )? )
       int alt152 = 2;
       int LA152_0 = input.LA(1);
@@ -20608,7 +21617,8 @@ public class JavaParser extends Parser {
       }
       switch (alt152) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1060:9: arrayDeclaratorList arrayInitializer
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1060:9: arrayDeclaratorList
+          // arrayInitializer
           {
             root_0 = (CommonTree) adaptor.nil();
 
@@ -20627,7 +21637,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:9: LBRACK expression RBRACK ( LBRACK
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:9: LBRACK expression
+          // RBRACK ( LBRACK
           // expression RBRACK )* ( arrayDeclaratorList )?
           {
             root_0 = (CommonTree) adaptor.nil();
@@ -20642,14 +21653,16 @@ public class JavaParser extends Parser {
             if (state.backtracking == 0) adaptor.addChild(root_0, expression523.getTree());
             RBRACK524 = (Token) match(input, RBRACK, FOLLOW_RBRACK_in_newArrayConstruction14697);
             if (state.failed) return retval;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:36: ( LBRACK expression RBRACK )*
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:36: ( LBRACK
+            // expression RBRACK )*
             loop150:
             do {
               int alt150 = 2;
               alt150 = dfa150.predict(input);
               switch (alt150) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:37: LBRACK expression RBRACK
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:37: LBRACK
+                  // expression RBRACK
                   {
                     LBRACK525 =
                         (Token) match(input, LBRACK, FOLLOW_LBRACK_in_newArrayConstruction14701);
@@ -20671,7 +21684,8 @@ public class JavaParser extends Parser {
               }
             } while (true);
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:66: ( arrayDeclaratorList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:66: (
+            // arrayDeclaratorList )?
             int alt151 = 2;
             int LA151_0 = input.LA(1);
 
@@ -20684,7 +21698,8 @@ public class JavaParser extends Parser {
             }
             switch (alt151) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: arrayDeclaratorList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                // arrayDeclaratorList
                 {
                   pushFollow(FOLLOW_arrayDeclaratorList_in_newArrayConstruction14711);
                   arrayDeclaratorList528 = arrayDeclaratorList();
@@ -20729,7 +21744,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "arguments"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1064:1: arguments : LPAREN ( expressionList )? RPAREN -> ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1064:1: arguments : LPAREN (
+  // expressionList )? RPAREN -> ^(
   // ARGUMENT_LIST[$LPAREN, \"ARGUMENT_LIST\"] ( expressionList )? ) ;
   public final JavaParser.arguments_return arguments() throws RecognitionException {
     JavaParser.arguments_return retval = new JavaParser.arguments_return();
@@ -20751,9 +21767,11 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 110)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1065:5: ( LPAREN ( expressionList )? RPAREN -> ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1065:5: ( LPAREN ( expressionList
+      // )? RPAREN -> ^(
       // ARGUMENT_LIST[$LPAREN, \"ARGUMENT_LIST\"] ( expressionList )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1065:9: LPAREN ( expressionList )? RPAREN
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1065:9: LPAREN ( expressionList
+      // )? RPAREN
       {
         LPAREN529 = (Token) match(input, LPAREN, FOLLOW_LPAREN_in_arguments14731);
         if (state.failed) return retval;
@@ -20820,7 +21838,8 @@ public class JavaParser extends Parser {
           root_0 = (CommonTree) adaptor.nil();
           // 1066:9: -> ^( ARGUMENT_LIST[$LPAREN, \"ARGUMENT_LIST\"] ( expressionList )? )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1066:13: ^( ARGUMENT_LIST[$LPAREN,
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1066:13: ^(
+            // ARGUMENT_LIST[$LPAREN,
             // \"ARGUMENT_LIST\"] ( expressionList )? )
             {
               CommonTree root_1 = (CommonTree) adaptor.nil();
@@ -20830,7 +21849,8 @@ public class JavaParser extends Parser {
                           (CommonTree) adaptor.create(ARGUMENT_LIST, LPAREN529, "ARGUMENT_LIST"),
                           root_1);
 
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1066:55: ( expressionList )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1066:55: ( expressionList
+              // )?
               if (stream_expressionList.hasNext()) {
                 adaptor.addChild(root_1, stream_expressionList.nextTree());
               }
@@ -20874,7 +21894,8 @@ public class JavaParser extends Parser {
   };
 
   // $ANTLR start "literal"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1069:1: literal : ( HEX_LITERAL | OCTAL_LITERAL | DECIMAL_LITERAL
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1069:1: literal : ( HEX_LITERAL |
+  // OCTAL_LITERAL | DECIMAL_LITERAL
   // | FLOATING_POINT_LITERAL | CHARACTER_LITERAL | STRING_LITERAL | TRUE | FALSE | NULL );
   public final JavaParser.literal_return literal() throws RecognitionException {
     JavaParser.literal_return retval = new JavaParser.literal_return();
@@ -20890,7 +21911,8 @@ public class JavaParser extends Parser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 111)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1070:5: ( HEX_LITERAL | OCTAL_LITERAL | DECIMAL_LITERAL |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1070:5: ( HEX_LITERAL |
+      // OCTAL_LITERAL | DECIMAL_LITERAL |
       // FLOATING_POINT_LITERAL | CHARACTER_LITERAL | STRING_LITERAL | TRUE | FALSE | NULL )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:
       {
@@ -21004,14 +22026,20 @@ public class JavaParser extends Parser {
   public final void synpred42_Java_fragment() throws RecognitionException {
     Token ident = null;
 
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( ( genericTypeParameterList )? ( type IDENT
-    // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList (
-    // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block ) )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( genericTypeParameterList )? ( type IDENT
-    // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList (
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( (
+    // genericTypeParameterList )? ( type IDENT
+    // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT
+    // formalParameterList (
+    // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block )
+    // )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( genericTypeParameterList
+    // )? ( type IDENT
+    // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT
+    // formalParameterList (
     // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block )
     {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( genericTypeParameterList )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: (
+      // genericTypeParameterList )?
       int alt159 = 2;
       int LA159_0 = input.LA(1);
 
@@ -21031,8 +22059,10 @@ public class JavaParser extends Parser {
           break;
       }
 
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:13: ( type IDENT formalParameterList (
-      // arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList ( throwsClause )? ( block |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:13: ( type IDENT
+      // formalParameterList (
+      // arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList
+      // ( throwsClause )? ( block |
       // SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block )
       int alt166 = 3;
       switch (input.LA(1)) {
@@ -21084,7 +22114,8 @@ public class JavaParser extends Parser {
 
       switch (alt166) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:17: type IDENT formalParameterList (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:17: type IDENT
+          // formalParameterList (
           // arrayDeclaratorList )? ( throwsClause )? ( block | SEMI )
           {
             pushFollow(FOLLOW_type_in_synpred42_Java5759);
@@ -21099,7 +22130,8 @@ public class JavaParser extends Parser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:48: ( arrayDeclaratorList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:48: (
+            // arrayDeclaratorList )?
             int alt160 = 2;
             int LA160_0 = input.LA(1);
 
@@ -21108,7 +22140,8 @@ public class JavaParser extends Parser {
             }
             switch (alt160) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: arrayDeclaratorList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                // arrayDeclaratorList
                 {
                   pushFollow(FOLLOW_arrayDeclaratorList_in_synpred42_Java5765);
                   arrayDeclaratorList();
@@ -21178,7 +22211,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:17: VOID IDENT formalParameterList (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:17: VOID IDENT
+          // formalParameterList (
           // throwsClause )? ( block | SEMI )
           {
             match(input, VOID, FOLLOW_VOID_in_synpred42_Java5838);
@@ -21249,7 +22283,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:17: ident= IDENT formalParameterList (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:17: ident= IDENT
+          // formalParameterList (
           // throwsClause )? block
           {
             ident = (Token) match(input, IDENT, FOLLOW_IDENT_in_synpred42_Java5911);
@@ -21295,13 +22330,19 @@ public class JavaParser extends Parser {
   public final void synpred43_Java_fragment() throws RecognitionException {
     Token ident = null;
 
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:452:9: ( modifierList ( ( genericTypeParameterList )? ( type
-    // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList (
-    // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block ) | type classFieldDeclaratorList
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:452:9: ( modifierList ( (
+    // genericTypeParameterList )? ( type
+    // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID
+    // IDENT formalParameterList (
+    // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block )
+    // | type classFieldDeclaratorList
     // SEMI ) )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:452:9: modifierList ( ( genericTypeParameterList )? ( type
-    // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList (
-    // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block ) | type classFieldDeclaratorList
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:452:9: modifierList ( (
+    // genericTypeParameterList )? ( type
+    // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID
+    // IDENT formalParameterList (
+    // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block )
+    // | type classFieldDeclaratorList
     // SEMI )
     {
       pushFollow(FOLLOW_modifierList_in_synpred43_Java5726);
@@ -21309,9 +22350,12 @@ public class JavaParser extends Parser {
 
       state._fsp--;
       if (state.failed) return;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:9: ( ( genericTypeParameterList )? ( type IDENT
-      // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList (
-      // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block ) | type
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:9: ( (
+      // genericTypeParameterList )? ( type IDENT
+      // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID
+      // IDENT formalParameterList (
+      // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block
+      // ) | type
       // classFieldDeclaratorList SEMI )
       int alt175 = 2;
       switch (input.LA(1)) {
@@ -21378,11 +22422,15 @@ public class JavaParser extends Parser {
 
       switch (alt175) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( genericTypeParameterList )? ( type IDENT
-          // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList (
-          // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: (
+          // genericTypeParameterList )? ( type IDENT
+          // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID
+          // IDENT formalParameterList (
+          // throwsClause )? ( block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )?
+          // block )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:453:13: (
+            // genericTypeParameterList )?
             int alt167 = 2;
             int LA167_0 = input.LA(1);
 
@@ -21391,7 +22439,8 @@ public class JavaParser extends Parser {
             }
             switch (alt167) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_synpred43_Java5740);
                   genericTypeParameterList();
@@ -21402,8 +22451,10 @@ public class JavaParser extends Parser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:13: ( type IDENT formalParameterList (
-            // arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT formalParameterList ( throwsClause )? (
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:13: ( type IDENT
+            // formalParameterList (
+            // arrayDeclaratorList )? ( throwsClause )? ( block | SEMI ) | VOID IDENT
+            // formalParameterList ( throwsClause )? (
             // block | SEMI ) | ident= IDENT formalParameterList ( throwsClause )? block )
             int alt174 = 3;
             switch (input.LA(1)) {
@@ -21458,7 +22509,8 @@ public class JavaParser extends Parser {
 
             switch (alt174) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:17: type IDENT formalParameterList (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:17: type IDENT
+                // formalParameterList (
                 // arrayDeclaratorList )? ( throwsClause )? ( block | SEMI )
                 {
                   pushFollow(FOLLOW_type_in_synpred43_Java5759);
@@ -21473,7 +22525,8 @@ public class JavaParser extends Parser {
 
                   state._fsp--;
                   if (state.failed) return;
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:48: ( arrayDeclaratorList )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:48: (
+                  // arrayDeclaratorList )?
                   int alt168 = 2;
                   int LA168_0 = input.LA(1);
 
@@ -21482,7 +22535,8 @@ public class JavaParser extends Parser {
                   }
                   switch (alt168) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: arrayDeclaratorList
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                      // arrayDeclaratorList
                       {
                         pushFollow(FOLLOW_arrayDeclaratorList_in_synpred43_Java5765);
                         arrayDeclaratorList();
@@ -21493,7 +22547,8 @@ public class JavaParser extends Parser {
                       break;
                   }
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:69: ( throwsClause )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:69: (
+                  // throwsClause )?
                   int alt169 = 2;
                   int LA169_0 = input.LA(1);
 
@@ -21513,7 +22568,8 @@ public class JavaParser extends Parser {
                       break;
                   }
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:83: ( block | SEMI )
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:454:83: ( block |
+                  // SEMI )
                   int alt170 = 2;
                   int LA170_0 = input.LA(1);
 
@@ -21552,7 +22608,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:17: VOID IDENT formalParameterList (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:17: VOID IDENT
+                // formalParameterList (
                 // throwsClause )? ( block | SEMI )
                 {
                   match(input, VOID, FOLLOW_VOID_in_synpred43_Java5838);
@@ -21564,7 +22621,8 @@ public class JavaParser extends Parser {
 
                   state._fsp--;
                   if (state.failed) return;
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:48: ( throwsClause )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:48: (
+                  // throwsClause )?
                   int alt171 = 2;
                   int LA171_0 = input.LA(1);
 
@@ -21584,7 +22642,8 @@ public class JavaParser extends Parser {
                       break;
                   }
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:62: ( block | SEMI )
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:456:62: ( block |
+                  // SEMI )
                   int alt172 = 2;
                   int LA172_0 = input.LA(1);
 
@@ -21623,7 +22682,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 3:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:17: ident= IDENT formalParameterList (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:17: ident= IDENT
+                // formalParameterList (
                 // throwsClause )? block
                 {
                   ident = (Token) match(input, IDENT, FOLLOW_IDENT_in_synpred43_Java5911);
@@ -21633,7 +22693,8 @@ public class JavaParser extends Parser {
 
                   state._fsp--;
                   if (state.failed) return;
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:49: ( throwsClause )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:458:49: (
+                  // throwsClause )?
                   int alt173 = 2;
                   int LA173_0 = input.LA(1);
 
@@ -21664,7 +22725,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:461:13: type classFieldDeclaratorList SEMI
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:461:13: type
+          // classFieldDeclaratorList SEMI
           {
             pushFollow(FOLLOW_type_in_synpred43_Java5982);
             type();
@@ -21701,12 +22763,17 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred50_Java
   public final void synpred50_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( ( genericTypeParameterList )? ( type IDENT
-    // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList ( throwsClause )? SEMI ) )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( genericTypeParameterList )? ( type IDENT
-    // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList ( throwsClause )? SEMI )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( (
+    // genericTypeParameterList )? ( type IDENT
+    // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT
+    // formalParameterList ( throwsClause )? SEMI ) )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( genericTypeParameterList
+    // )? ( type IDENT
+    // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT
+    // formalParameterList ( throwsClause )? SEMI )
     {
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( genericTypeParameterList )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: (
+      // genericTypeParameterList )?
       int alt178 = 2;
       int LA178_0 = input.LA(1);
 
@@ -21726,8 +22793,10 @@ public class JavaParser extends Parser {
           break;
       }
 
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:13: ( type IDENT formalParameterList (
-      // arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList ( throwsClause )? SEMI )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:13: ( type IDENT
+      // formalParameterList (
+      // arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList (
+      // throwsClause )? SEMI )
       int alt182 = 2;
       int LA182_0 = input.LA(1);
 
@@ -21753,7 +22822,8 @@ public class JavaParser extends Parser {
       }
       switch (alt182) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:17: type IDENT formalParameterList (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:17: type IDENT
+          // formalParameterList (
           // arrayDeclaratorList )? ( throwsClause )? SEMI
           {
             pushFollow(FOLLOW_type_in_synpred50_Java6106);
@@ -21768,7 +22838,8 @@ public class JavaParser extends Parser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:48: ( arrayDeclaratorList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:48: (
+            // arrayDeclaratorList )?
             int alt179 = 2;
             int LA179_0 = input.LA(1);
 
@@ -21777,7 +22848,8 @@ public class JavaParser extends Parser {
             }
             switch (alt179) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: arrayDeclaratorList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                // arrayDeclaratorList
                 {
                   pushFollow(FOLLOW_arrayDeclaratorList_in_synpred50_Java6112);
                   arrayDeclaratorList();
@@ -21813,7 +22885,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:17: VOID IDENT formalParameterList (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:17: VOID IDENT
+          // formalParameterList (
           // throwsClause )? SEMI
           {
             match(input, VOID, FOLLOW_VOID_in_synpred50_Java6176);
@@ -21856,11 +22929,15 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred51_Java
   public final void synpred51_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:469:9: ( modifierList ( ( genericTypeParameterList )? ( type
-    // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList ( throwsClause )?
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:469:9: ( modifierList ( (
+    // genericTypeParameterList )? ( type
+    // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT
+    // formalParameterList ( throwsClause )?
     // SEMI ) | type interfaceFieldDeclaratorList SEMI ) )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:469:9: modifierList ( ( genericTypeParameterList )? ( type
-    // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList ( throwsClause )?
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:469:9: modifierList ( (
+    // genericTypeParameterList )? ( type
+    // IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT
+    // formalParameterList ( throwsClause )?
     // SEMI ) | type interfaceFieldDeclaratorList SEMI )
     {
       pushFollow(FOLLOW_modifierList_in_synpred51_Java6073);
@@ -21868,8 +22945,10 @@ public class JavaParser extends Parser {
 
       state._fsp--;
       if (state.failed) return;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:9: ( ( genericTypeParameterList )? ( type IDENT
-      // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList ( throwsClause )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:9: ( (
+      // genericTypeParameterList )? ( type IDENT
+      // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT
+      // formalParameterList ( throwsClause )?
       // SEMI ) | type interfaceFieldDeclaratorList SEMI )
       int alt188 = 2;
       switch (input.LA(1)) {
@@ -21936,11 +23015,14 @@ public class JavaParser extends Parser {
 
       switch (alt188) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( genericTypeParameterList )? ( type IDENT
-          // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: (
+          // genericTypeParameterList )? ( type IDENT
+          // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT
+          // formalParameterList (
           // throwsClause )? SEMI )
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:470:13: (
+            // genericTypeParameterList )?
             int alt183 = 2;
             int LA183_0 = input.LA(1);
 
@@ -21949,7 +23031,8 @@ public class JavaParser extends Parser {
             }
             switch (alt183) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_synpred51_Java6087);
                   genericTypeParameterList();
@@ -21960,8 +23043,10 @@ public class JavaParser extends Parser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:13: ( type IDENT formalParameterList (
-            // arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList ( throwsClause )? SEMI )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:13: ( type IDENT
+            // formalParameterList (
+            // arrayDeclaratorList )? ( throwsClause )? SEMI | VOID IDENT formalParameterList (
+            // throwsClause )? SEMI )
             int alt187 = 2;
             int LA187_0 = input.LA(1);
 
@@ -21987,7 +23072,8 @@ public class JavaParser extends Parser {
             }
             switch (alt187) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:17: type IDENT formalParameterList (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:17: type IDENT
+                // formalParameterList (
                 // arrayDeclaratorList )? ( throwsClause )? SEMI
                 {
                   pushFollow(FOLLOW_type_in_synpred51_Java6106);
@@ -22002,7 +23088,8 @@ public class JavaParser extends Parser {
 
                   state._fsp--;
                   if (state.failed) return;
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:48: ( arrayDeclaratorList )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:48: (
+                  // arrayDeclaratorList )?
                   int alt184 = 2;
                   int LA184_0 = input.LA(1);
 
@@ -22011,7 +23098,8 @@ public class JavaParser extends Parser {
                   }
                   switch (alt184) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: arrayDeclaratorList
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                      // arrayDeclaratorList
                       {
                         pushFollow(FOLLOW_arrayDeclaratorList_in_synpred51_Java6112);
                         arrayDeclaratorList();
@@ -22022,7 +23110,8 @@ public class JavaParser extends Parser {
                       break;
                   }
 
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:69: ( throwsClause )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:471:69: (
+                  // throwsClause )?
                   int alt185 = 2;
                   int LA185_0 = input.LA(1);
 
@@ -22047,7 +23136,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:17: VOID IDENT formalParameterList (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:17: VOID IDENT
+                // formalParameterList (
                 // throwsClause )? SEMI
                 {
                   match(input, VOID, FOLLOW_VOID_in_synpred51_Java6176);
@@ -22059,7 +23149,8 @@ public class JavaParser extends Parser {
 
                   state._fsp--;
                   if (state.failed) return;
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:48: ( throwsClause )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:473:48: (
+                  // throwsClause )?
                   int alt186 = 2;
                   int LA186_0 = input.LA(1);
 
@@ -22087,7 +23178,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:476:13: type interfaceFieldDeclaratorList SEMI
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:476:13: type
+          // interfaceFieldDeclaratorList SEMI
           {
             pushFollow(FOLLOW_type_in_synpred51_Java6248);
             type();
@@ -22182,7 +23274,8 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred90_Java
   public final void synpred90_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:40: ( COMMA genericTypeArgument )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:40: ( COMMA genericTypeArgument
+    // )
     // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:611:40: COMMA genericTypeArgument
     {
       match(input, COMMA, FOLLOW_COMMA_in_synpred90_Java7361);
@@ -22198,7 +23291,8 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred92_Java
   public final void synpred92_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:617:18: ( genericWildcardBoundType )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:617:18: ( genericWildcardBoundType
+    // )
     // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:617:18: genericWildcardBoundType
     {
       pushFollow(FOLLOW_genericWildcardBoundType_in_synpred92_Java7417);
@@ -22212,8 +23306,10 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred97_Java
   public final void synpred97_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:42: ( COMMA formalParameterStandardDecl )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:42: COMMA formalParameterStandardDecl
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:42: ( COMMA
+    // formalParameterStandardDecl )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:42: COMMA
+    // formalParameterStandardDecl
     {
       match(input, COMMA, FOLLOW_COMMA_in_synpred97_Java7635);
       if (state.failed) return;
@@ -22228,9 +23324,11 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred99_Java
   public final void synpred99_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:13: ( formalParameterStandardDecl ( COMMA
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:13: (
+    // formalParameterStandardDecl ( COMMA
     // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )? )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:13: formalParameterStandardDecl ( COMMA
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:13: formalParameterStandardDecl
+    // ( COMMA
     // formalParameterStandardDecl )* ( COMMA formalParameterVarArgDecl )?
     {
       pushFollow(FOLLOW_formalParameterStandardDecl_in_synpred99_Java7632);
@@ -22238,7 +23336,8 @@ public class JavaParser extends Parser {
 
       state._fsp--;
       if (state.failed) return;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:41: ( COMMA formalParameterStandardDecl )*
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:41: ( COMMA
+      // formalParameterStandardDecl )*
       loop191:
       do {
         int alt191 = 2;
@@ -22254,7 +23353,8 @@ public class JavaParser extends Parser {
 
         switch (alt191) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:42: COMMA formalParameterStandardDecl
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:42: COMMA
+            // formalParameterStandardDecl
             {
               match(input, COMMA, FOLLOW_COMMA_in_synpred99_Java7635);
               if (state.failed) return;
@@ -22271,7 +23371,8 @@ public class JavaParser extends Parser {
         }
       } while (true);
 
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:78: ( COMMA formalParameterVarArgDecl )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:78: ( COMMA
+      // formalParameterVarArgDecl )?
       int alt192 = 2;
       int LA192_0 = input.LA(1);
 
@@ -22280,7 +23381,8 @@ public class JavaParser extends Parser {
       }
       switch (alt192) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:79: COMMA formalParameterVarArgDecl
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:642:79: COMMA
+          // formalParameterVarArgDecl
           {
             match(input, COMMA, FOLLOW_COMMA_in_synpred99_Java7642);
             if (state.failed) return;
@@ -22298,7 +23400,8 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred100_Java
   public final void synpred100_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:645:13: ( formalParameterVarArgDecl )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:645:13: ( formalParameterVarArgDecl
+    // )
     // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:645:13: formalParameterVarArgDecl
     {
       pushFollow(FOLLOW_formalParameterVarArgDecl_in_synpred100_Java7701);
@@ -22341,9 +23444,11 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred114_Java
   public final void synpred114_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:724:9: ( modifierList type ( IDENT LPAREN RPAREN (
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:724:9: ( modifierList type ( IDENT
+    // LPAREN RPAREN (
     // annotationDefaultValue )? SEMI | classFieldDeclaratorList SEMI ) )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:724:9: modifierList type ( IDENT LPAREN RPAREN (
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:724:9: modifierList type ( IDENT
+    // LPAREN RPAREN (
     // annotationDefaultValue )? SEMI | classFieldDeclaratorList SEMI )
     {
       pushFollow(FOLLOW_modifierList_in_synpred114_Java8457);
@@ -22356,7 +23461,8 @@ public class JavaParser extends Parser {
 
       state._fsp--;
       if (state.failed) return;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:9: ( IDENT LPAREN RPAREN ( annotationDefaultValue )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:9: ( IDENT LPAREN RPAREN (
+      // annotationDefaultValue )?
       // SEMI | classFieldDeclaratorList SEMI )
       int alt197 = 2;
       int LA197_0 = input.LA(1);
@@ -22400,7 +23506,8 @@ public class JavaParser extends Parser {
             if (state.failed) return;
             match(input, RPAREN, FOLLOW_RPAREN_in_synpred114_Java8477);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:33: ( annotationDefaultValue )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:725:33: (
+            // annotationDefaultValue )?
             int alt196 = 2;
             int LA196_0 = input.LA(1);
 
@@ -22409,7 +23516,8 @@ public class JavaParser extends Parser {
             }
             switch (alt196) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0: annotationDefaultValue
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:0:0:
+                // annotationDefaultValue
                 {
                   pushFollow(FOLLOW_annotationDefaultValue_in_synpred114_Java8479);
                   annotationDefaultValue();
@@ -22425,7 +23533,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:727:13: classFieldDeclaratorList SEMI
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:727:13:
+          // classFieldDeclaratorList SEMI
           {
             pushFollow(FOLLOW_classFieldDeclaratorList_in_synpred114_Java8524);
             classFieldDeclaratorList();
@@ -22443,8 +23552,10 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred116_Java
   public final void synpred116_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:745:9: ( localVariableDeclaration SEMI )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:745:9: localVariableDeclaration SEMI
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:745:9: ( localVariableDeclaration
+    // SEMI )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:745:9: localVariableDeclaration
+    // SEMI
     {
       pushFollow(FOLLOW_localVariableDeclaration_in_synpred116_Java8661);
       localVariableDeclaration();
@@ -22475,7 +23586,8 @@ public class JavaParser extends Parser {
   public final void synpred121_Java_fragment() throws RecognitionException {
     JavaParser.statement_return elseStat = null;
 
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:763:13: ( ELSE elseStat= statement )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:763:13: ( ELSE elseStat= statement
+    // )
     // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:763:13: ELSE elseStat= statement
     {
       match(input, ELSE, FOLLOW_ELSE_in_synpred121_Java8972);
@@ -22491,9 +23603,11 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred123_Java
   public final void synpred123_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:13: ( forInit SEMI forCondition SEMI forUpdater RPAREN
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:13: ( forInit SEMI forCondition
+    // SEMI forUpdater RPAREN
     // statement )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:13: forInit SEMI forCondition SEMI forUpdater RPAREN
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:767:13: forInit SEMI forCondition
+    // SEMI forUpdater RPAREN
     // statement
     {
       pushFollow(FOLLOW_forInit_in_synpred123_Java9159);
@@ -22570,8 +23684,10 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred190_Java
   public final void synpred190_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:954:9: ( LPAREN type RPAREN unaryExpression )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:954:9: LPAREN type RPAREN unaryExpression
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:954:9: ( LPAREN type RPAREN
+    // unaryExpression )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:954:9: LPAREN type RPAREN
+    // unaryExpression
     {
       match(input, LPAREN, FOLLOW_LPAREN_in_synpred190_Java11783);
       if (state.failed) return;
@@ -22593,8 +23709,10 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred218_Java
   public final void synpred218_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: ( ( arrayDeclarator )+ ( DOT CLASS ) )
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: ( arrayDeclarator )+ ( DOT CLASS )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: ( ( arrayDeclarator )+ (
+    // DOT CLASS ) )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: ( arrayDeclarator )+ ( DOT
+    // CLASS )
     {
       // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1022:13: ( arrayDeclarator )+
       int cnt220 = 0;
@@ -22650,16 +23768,20 @@ public class JavaParser extends Parser {
     Token innerDot = null;
 
     // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1027:13: (outerDot= DOT ( CLASS |
-    // genericTypeArgumentListSimplified (Super= SUPER arguments | SUPER innerDot= DOT IDENT arguments | IDENT arguments ) | THIS |
+    // genericTypeArgumentListSimplified (Super= SUPER arguments | SUPER innerDot= DOT IDENT
+    // arguments | IDENT arguments ) | THIS |
     // Super= SUPER arguments | innerNewExpression ) )
     // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1027:13: outerDot= DOT ( CLASS |
-    // genericTypeArgumentListSimplified (Super= SUPER arguments | SUPER innerDot= DOT IDENT arguments | IDENT arguments ) | THIS |
+    // genericTypeArgumentListSimplified (Super= SUPER arguments | SUPER innerDot= DOT IDENT
+    // arguments | IDENT arguments ) | THIS |
     // Super= SUPER arguments | innerNewExpression )
     {
       outerDot = (Token) match(input, DOT, FOLLOW_DOT_in_synpred226_Java13891);
       if (state.failed) return;
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1028:13: ( CLASS | genericTypeArgumentListSimplified
-      // (Super= SUPER arguments | SUPER innerDot= DOT IDENT arguments | IDENT arguments ) | THIS | Super= SUPER arguments |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1028:13: ( CLASS |
+      // genericTypeArgumentListSimplified
+      // (Super= SUPER arguments | SUPER innerDot= DOT IDENT arguments | IDENT arguments ) | THIS |
+      // Super= SUPER arguments |
       // innerNewExpression )
       int alt223 = 5;
       switch (input.LA(1)) {
@@ -22707,7 +23829,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1029:17: genericTypeArgumentListSimplified (Super=
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1029:17:
+          // genericTypeArgumentListSimplified (Super=
           // SUPER arguments | SUPER innerDot= DOT IDENT arguments | IDENT arguments )
           {
             pushFollow(FOLLOW_genericTypeArgumentListSimplified_in_synpred226_Java13972);
@@ -22715,7 +23838,8 @@ public class JavaParser extends Parser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:17: (Super= SUPER arguments | SUPER innerDot=
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:17: (Super= SUPER
+            // arguments | SUPER innerDot=
             // DOT IDENT arguments | IDENT arguments )
             int alt222 = 3;
             int LA222_0 = input.LA(1);
@@ -22749,7 +23873,8 @@ public class JavaParser extends Parser {
             }
             switch (alt222) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:21: Super= SUPER arguments
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1030:21: Super= SUPER
+                // arguments
                 {
                   Super = (Token) match(input, SUPER, FOLLOW_SUPER_in_synpred226_Java13997);
                   if (state.failed) return;
@@ -22761,7 +23886,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1031:21: SUPER innerDot= DOT IDENT arguments
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1031:21: SUPER
+                // innerDot= DOT IDENT arguments
                 {
                   match(input, SUPER, FOLLOW_SUPER_in_synpred226_Java14049);
                   if (state.failed) return;
@@ -22777,7 +23903,8 @@ public class JavaParser extends Parser {
                 }
                 break;
               case 3:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1032:21: IDENT arguments
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1032:21: IDENT
+                // arguments
                 {
                   match(input, IDENT, FOLLOW_IDENT_in_synpred226_Java14107);
                   if (state.failed) return;
@@ -22799,7 +23926,8 @@ public class JavaParser extends Parser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1035:17: Super= SUPER arguments
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1035:17: Super= SUPER
+          // arguments
           {
             Super = (Token) match(input, SUPER, FOLLOW_SUPER_in_synpred226_Java14250);
             if (state.failed) return;
@@ -22827,7 +23955,8 @@ public class JavaParser extends Parser {
 
   // $ANTLR start synpred234_Java
   public final void synpred234_Java_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:37: ( LBRACK expression RBRACK )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:37: ( LBRACK expression RBRACK
+    // )
     // org/eclipse/che/ide/ext/java/jdi/server/expression/Java.g:1061:37: LBRACK expression RBRACK
     {
       match(input, LBRACK, FOLLOW_LBRACK_in_synpred234_Java14701);

--- a/antlr-java5-grammar/src/main/java/org/eclipse/che/plugin/jdb/server/expression/JavaTreeParser.java
+++ b/antlr-java5-grammar/src/main/java/org/eclipse/che/plugin/jdb/server/expression/JavaTreeParser.java
@@ -8,7 +8,8 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-// $ANTLR 3.3 Nov 30, 2010 12:50:56 org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g 2013-02-07 15:54:13
+// $ANTLR 3.3 Nov 30, 2010 12:50:56
+// org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g 2013-02-07 15:54:13
 
 package org.eclipse.che.plugin.jdb.server.expression;
 
@@ -527,7 +528,8 @@ public class JavaTreeParser extends TreeParser {
   }
 
   // $ANTLR start "javaSource"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:141:1: javaSource : ^( JAVA_SOURCE annotationList (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:141:1: javaSource : ^(
+  // JAVA_SOURCE annotationList (
   // packageDeclaration )? ( importDeclaration )* ( typeDeclaration )* ) ;
   public final void javaSource() throws RecognitionException {
     int javaSource_StartIndex = input.index();
@@ -535,9 +537,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 1)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:142:3: ( ^( JAVA_SOURCE annotationList (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:142:3: ( ^( JAVA_SOURCE
+      // annotationList (
       // packageDeclaration )? ( importDeclaration )* ( typeDeclaration )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:143:3: ^( JAVA_SOURCE annotationList (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:143:3: ^( JAVA_SOURCE
+      // annotationList (
       // packageDeclaration )? ( importDeclaration )* ( typeDeclaration )* )
       {
         match(input, JAVA_SOURCE, FOLLOW_JAVA_SOURCE_in_javaSource90);
@@ -550,7 +554,8 @@ public class JavaTreeParser extends TreeParser {
 
         state._fsp--;
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:143:32: ( packageDeclaration )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:143:32: (
+        // packageDeclaration )?
         int alt1 = 2;
         int LA1_0 = input.LA(1);
 
@@ -559,7 +564,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt1) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: packageDeclaration
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+            // packageDeclaration
             {
               pushFollow(FOLLOW_packageDeclaration_in_javaSource94);
               packageDeclaration();
@@ -570,7 +576,8 @@ public class JavaTreeParser extends TreeParser {
             break;
         }
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:143:52: ( importDeclaration )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:143:52: (
+        // importDeclaration )*
         loop2:
         do {
           int alt2 = 2;
@@ -582,7 +589,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt2) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: importDeclaration
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // importDeclaration
               {
                 pushFollow(FOLLOW_importDeclaration_in_javaSource97);
                 importDeclaration();
@@ -597,7 +605,8 @@ public class JavaTreeParser extends TreeParser {
           }
         } while (true);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:143:71: ( typeDeclaration )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:143:71: (
+        // typeDeclaration )*
         loop3:
         do {
           int alt3 = 2;
@@ -609,7 +618,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt3) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: typeDeclaration
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // typeDeclaration
               {
                 pushFollow(FOLLOW_typeDeclaration_in_javaSource100);
                 typeDeclaration();
@@ -641,7 +651,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "javaSource"
 
   // $ANTLR start "packageDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:146:1: packageDeclaration : ^( PACKAGE
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:146:1: packageDeclaration :
+  // ^( PACKAGE
   // qualifiedIdentifier ) ;
   public final void packageDeclaration() throws RecognitionException {
     int packageDeclaration_StartIndex = input.index();
@@ -649,8 +660,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 2)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:147:3: ( ^( PACKAGE qualifiedIdentifier ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:148:3: ^( PACKAGE qualifiedIdentifier )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:147:3: ( ^( PACKAGE
+      // qualifiedIdentifier ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:148:3: ^( PACKAGE
+      // qualifiedIdentifier )
       {
         match(input, PACKAGE, FOLLOW_PACKAGE_in_packageDeclaration118);
         if (state.failed) return;
@@ -680,7 +693,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "packageDeclaration"
 
   // $ANTLR start "importDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:151:1: importDeclaration : ^( IMPORT ( STATIC )?
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:151:1: importDeclaration :
+  // ^( IMPORT ( STATIC )?
   // qualifiedIdentifier ( DOTSTAR )? ) ;
   public final void importDeclaration() throws RecognitionException {
     int importDeclaration_StartIndex = input.index();
@@ -688,9 +702,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 3)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:152:3: ( ^( IMPORT ( STATIC )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:152:3: ( ^( IMPORT (
+      // STATIC )?
       // qualifiedIdentifier ( DOTSTAR )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:153:3: ^( IMPORT ( STATIC )? qualifiedIdentifier
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:153:3: ^( IMPORT (
+      // STATIC )? qualifiedIdentifier
       // ( DOTSTAR )? )
       {
         match(input, IMPORT, FOLLOW_IMPORT_in_importDeclaration137);
@@ -754,9 +770,12 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "importDeclaration"
 
   // $ANTLR start "typeDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:156:1: typeDeclaration : ( ^( CLASS modifierList IDENT (
-  // genericTypeParameterList )? ( extendsClause )? ( implementsClause )? classTopLevelScope ) | ^( INTERFACE modifierList IDENT (
-  // genericTypeParameterList )? ( extendsClause )? interfaceTopLevelScope ) | ^( ENUM modifierList IDENT ( implementsClause )?
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:156:1: typeDeclaration : (
+  // ^( CLASS modifierList IDENT (
+  // genericTypeParameterList )? ( extendsClause )? ( implementsClause )? classTopLevelScope ) | ^(
+  // INTERFACE modifierList IDENT (
+  // genericTypeParameterList )? ( extendsClause )? interfaceTopLevelScope ) | ^( ENUM modifierList
+  // IDENT ( implementsClause )?
   // enumTopLevelScope ) | ^( AT modifierList IDENT annotationTopLevelScope ) );
   public final void typeDeclaration() throws RecognitionException {
     int typeDeclaration_StartIndex = input.index();
@@ -764,10 +783,14 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 4)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:157:3: ( ^( CLASS modifierList IDENT (
-      // genericTypeParameterList )? ( extendsClause )? ( implementsClause )? classTopLevelScope ) | ^( INTERFACE modifierList
-      // IDENT ( genericTypeParameterList )? ( extendsClause )? interfaceTopLevelScope ) | ^( ENUM modifierList IDENT (
-      // implementsClause )? enumTopLevelScope ) | ^( AT modifierList IDENT annotationTopLevelScope ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:157:3: ( ^( CLASS
+      // modifierList IDENT (
+      // genericTypeParameterList )? ( extendsClause )? ( implementsClause )? classTopLevelScope ) |
+      // ^( INTERFACE modifierList
+      // IDENT ( genericTypeParameterList )? ( extendsClause )? interfaceTopLevelScope ) | ^( ENUM
+      // modifierList IDENT (
+      // implementsClause )? enumTopLevelScope ) | ^( AT modifierList IDENT annotationTopLevelScope
+      // ) )
       int alt12 = 4;
       switch (input.LA(1)) {
         case CLASS:
@@ -802,8 +825,10 @@ public class JavaTreeParser extends TreeParser {
 
       switch (alt12) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:158:3: ^( CLASS modifierList IDENT (
-          // genericTypeParameterList )? ( extendsClause )? ( implementsClause )? classTopLevelScope )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:158:3: ^( CLASS
+          // modifierList IDENT (
+          // genericTypeParameterList )? ( extendsClause )? ( implementsClause )? classTopLevelScope
+          // )
           {
             match(input, CLASS, FOLLOW_CLASS_in_typeDeclaration162);
             if (state.failed) return;
@@ -817,7 +842,8 @@ public class JavaTreeParser extends TreeParser {
             if (state.failed) return;
             match(input, IDENT, FOLLOW_IDENT_in_typeDeclaration166);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:158:30: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:158:30: (
+            // genericTypeParameterList )?
             int alt6 = 2;
             int LA6_0 = input.LA(1);
 
@@ -826,7 +852,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt6) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_typeDeclaration168);
                   genericTypeParameterList();
@@ -837,7 +864,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:158:56: ( extendsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:158:56: (
+            // extendsClause )?
             int alt7 = 2;
             int LA7_0 = input.LA(1);
 
@@ -846,7 +874,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt7) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: extendsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // extendsClause
                 {
                   pushFollow(FOLLOW_extendsClause_in_typeDeclaration171);
                   extendsClause();
@@ -857,7 +886,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:158:71: ( implementsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:158:71: (
+            // implementsClause )?
             int alt8 = 2;
             int LA8_0 = input.LA(1);
 
@@ -866,7 +896,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt8) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: implementsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // implementsClause
                 {
                   pushFollow(FOLLOW_implementsClause_in_typeDeclaration174);
                   implementsClause();
@@ -888,7 +919,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:160:3: ^( INTERFACE modifierList IDENT (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:160:3: ^( INTERFACE
+          // modifierList IDENT (
           // genericTypeParameterList )? ( extendsClause )? interfaceTopLevelScope )
           {
             match(input, INTERFACE, FOLLOW_INTERFACE_in_typeDeclaration187);
@@ -903,7 +935,8 @@ public class JavaTreeParser extends TreeParser {
             if (state.failed) return;
             match(input, IDENT, FOLLOW_IDENT_in_typeDeclaration191);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:160:34: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:160:34: (
+            // genericTypeParameterList )?
             int alt9 = 2;
             int LA9_0 = input.LA(1);
 
@@ -912,7 +945,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt9) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_typeDeclaration193);
                   genericTypeParameterList();
@@ -923,7 +957,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:160:60: ( extendsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:160:60: (
+            // extendsClause )?
             int alt10 = 2;
             int LA10_0 = input.LA(1);
 
@@ -932,7 +967,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt10) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: extendsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // extendsClause
                 {
                   pushFollow(FOLLOW_extendsClause_in_typeDeclaration196);
                   extendsClause();
@@ -954,7 +990,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:162:3: ^( ENUM modifierList IDENT (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:162:3: ^( ENUM
+          // modifierList IDENT (
           // implementsClause )? enumTopLevelScope )
           {
             match(input, ENUM, FOLLOW_ENUM_in_typeDeclaration209);
@@ -969,7 +1006,8 @@ public class JavaTreeParser extends TreeParser {
             if (state.failed) return;
             match(input, IDENT, FOLLOW_IDENT_in_typeDeclaration213);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:162:29: ( implementsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:162:29: (
+            // implementsClause )?
             int alt11 = 2;
             int LA11_0 = input.LA(1);
 
@@ -978,7 +1016,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt11) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: implementsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // implementsClause
                 {
                   pushFollow(FOLLOW_implementsClause_in_typeDeclaration215);
                   implementsClause();
@@ -1000,7 +1039,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:164:3: ^( AT modifierList IDENT
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:164:3: ^( AT
+          // modifierList IDENT
           // annotationTopLevelScope )
           {
             match(input, AT, FOLLOW_AT_in_typeDeclaration228);
@@ -1039,15 +1079,18 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "typeDeclaration"
 
   // $ANTLR start "extendsClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:167:1: extendsClause : ^( EXTENDS_CLAUSE ( type )+ ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:167:1: extendsClause : ^(
+  // EXTENDS_CLAUSE ( type )+ ) ;
   public final void extendsClause() throws RecognitionException {
     int extendsClause_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 5)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:169:3: ( ^( EXTENDS_CLAUSE ( type )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:170:3: ^( EXTENDS_CLAUSE ( type )+ )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:169:3: ( ^(
+      // EXTENDS_CLAUSE ( type )+ ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:170:3: ^(
+      // EXTENDS_CLAUSE ( type )+ )
       {
         match(input, EXTENDS_CLAUSE, FOLLOW_EXTENDS_CLAUSE_in_extendsClause255);
         if (state.failed) return;
@@ -1106,7 +1149,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "extendsClause"
 
   // $ANTLR start "implementsClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:173:1: implementsClause : ^( IMPLEMENTS_CLAUSE ( type )+
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:173:1: implementsClause :
+  // ^( IMPLEMENTS_CLAUSE ( type )+
   // ) ;
   public final void implementsClause() throws RecognitionException {
     int implementsClause_StartIndex = input.index();
@@ -1114,8 +1158,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 6)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:174:3: ( ^( IMPLEMENTS_CLAUSE ( type )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:175:3: ^( IMPLEMENTS_CLAUSE ( type )+ )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:174:3: ( ^(
+      // IMPLEMENTS_CLAUSE ( type )+ ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:175:3: ^(
+      // IMPLEMENTS_CLAUSE ( type )+ )
       {
         match(input, IMPLEMENTS_CLAUSE, FOLLOW_IMPLEMENTS_CLAUSE_in_implementsClause275);
         if (state.failed) return;
@@ -1174,7 +1220,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "implementsClause"
 
   // $ANTLR start "genericTypeParameterList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:178:1: genericTypeParameterList : ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:178:1:
+  // genericTypeParameterList : ^(
   // GENERIC_TYPE_PARAM_LIST ( genericTypeParameter )+ ) ;
   public final void genericTypeParameterList() throws RecognitionException {
     int genericTypeParameterList_StartIndex = input.index();
@@ -1182,9 +1229,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 7)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:179:3: ( ^( GENERIC_TYPE_PARAM_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:179:3: ( ^(
+      // GENERIC_TYPE_PARAM_LIST (
       // genericTypeParameter )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:180:3: ^( GENERIC_TYPE_PARAM_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:180:3: ^(
+      // GENERIC_TYPE_PARAM_LIST (
       // genericTypeParameter )+ )
       {
         match(
@@ -1195,7 +1244,8 @@ public class JavaTreeParser extends TreeParser {
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:180:29: ( genericTypeParameter )+
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:180:29: (
+        // genericTypeParameter )+
         int cnt15 = 0;
         loop15:
         do {
@@ -1208,7 +1258,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt15) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeParameter
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // genericTypeParameter
               {
                 pushFollow(FOLLOW_genericTypeParameter_in_genericTypeParameterList297);
                 genericTypeParameter();
@@ -1247,15 +1298,18 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "genericTypeParameterList"
 
   // $ANTLR start "genericTypeParameter"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:183:1: genericTypeParameter : ^( IDENT ( bound )? ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:183:1: genericTypeParameter
+  // : ^( IDENT ( bound )? ) ;
   public final void genericTypeParameter() throws RecognitionException {
     int genericTypeParameter_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 8)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:184:3: ( ^( IDENT ( bound )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:185:3: ^( IDENT ( bound )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:184:3: ( ^( IDENT (
+      // bound )? ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:185:3: ^( IDENT ( bound
+      // )? )
       {
         match(input, IDENT, FOLLOW_IDENT_in_genericTypeParameter315);
         if (state.failed) return;
@@ -1301,15 +1355,18 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "genericTypeParameter"
 
   // $ANTLR start "bound"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:188:1: bound : ^( EXTENDS_BOUND_LIST ( type )+ ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:188:1: bound : ^(
+  // EXTENDS_BOUND_LIST ( type )+ ) ;
   public final void bound() throws RecognitionException {
     int bound_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 9)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:189:3: ( ^( EXTENDS_BOUND_LIST ( type )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:190:3: ^( EXTENDS_BOUND_LIST ( type )+ )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:189:3: ( ^(
+      // EXTENDS_BOUND_LIST ( type )+ ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:190:3: ^(
+      // EXTENDS_BOUND_LIST ( type )+ )
       {
         match(input, EXTENDS_BOUND_LIST, FOLLOW_EXTENDS_BOUND_LIST_in_bound335);
         if (state.failed) return;
@@ -1368,7 +1425,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "bound"
 
   // $ANTLR start "enumTopLevelScope"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:193:1: enumTopLevelScope : ^( ENUM_TOP_LEVEL_SCOPE (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:193:1: enumTopLevelScope :
+  // ^( ENUM_TOP_LEVEL_SCOPE (
   // enumConstant )+ ( classTopLevelScope )? ) ;
   public final void enumTopLevelScope() throws RecognitionException {
     int enumTopLevelScope_StartIndex = input.index();
@@ -1376,9 +1434,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 10)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:194:3: ( ^( ENUM_TOP_LEVEL_SCOPE ( enumConstant
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:194:3: ( ^(
+      // ENUM_TOP_LEVEL_SCOPE ( enumConstant
       // )+ ( classTopLevelScope )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:195:3: ^( ENUM_TOP_LEVEL_SCOPE ( enumConstant )+
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:195:3: ^(
+      // ENUM_TOP_LEVEL_SCOPE ( enumConstant )+
       // ( classTopLevelScope )? )
       {
         match(input, ENUM_TOP_LEVEL_SCOPE, FOLLOW_ENUM_TOP_LEVEL_SCOPE_in_enumTopLevelScope355);
@@ -1386,7 +1446,8 @@ public class JavaTreeParser extends TreeParser {
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:195:26: ( enumConstant )+
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:195:26: (
+        // enumConstant )+
         int cnt18 = 0;
         loop18:
         do {
@@ -1399,7 +1460,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt18) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: enumConstant
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // enumConstant
               {
                 pushFollow(FOLLOW_enumConstant_in_enumTopLevelScope357);
                 enumConstant();
@@ -1421,7 +1483,8 @@ public class JavaTreeParser extends TreeParser {
           cnt18++;
         } while (true);
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:195:40: ( classTopLevelScope )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:195:40: (
+        // classTopLevelScope )?
         int alt19 = 2;
         int LA19_0 = input.LA(1);
 
@@ -1430,7 +1493,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt19) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: classTopLevelScope
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+            // classTopLevelScope
             {
               pushFollow(FOLLOW_classTopLevelScope_in_enumTopLevelScope360);
               classTopLevelScope();
@@ -1458,7 +1522,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "enumTopLevelScope"
 
   // $ANTLR start "enumConstant"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:198:1: enumConstant : ^( IDENT annotationList (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:198:1: enumConstant : ^(
+  // IDENT annotationList (
   // arguments )? ( classTopLevelScope )? ) ;
   public final void enumConstant() throws RecognitionException {
     int enumConstant_StartIndex = input.index();
@@ -1466,9 +1531,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 11)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:199:3: ( ^( IDENT annotationList ( arguments )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:199:3: ( ^( IDENT
+      // annotationList ( arguments )?
       // ( classTopLevelScope )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:200:3: ^( IDENT annotationList ( arguments )? (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:200:3: ^( IDENT
+      // annotationList ( arguments )? (
       // classTopLevelScope )? )
       {
         match(input, IDENT, FOLLOW_IDENT_in_enumConstant378);
@@ -1481,7 +1548,8 @@ public class JavaTreeParser extends TreeParser {
 
         state._fsp--;
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:200:26: ( arguments )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:200:26: ( arguments
+        // )?
         int alt20 = 2;
         int LA20_0 = input.LA(1);
 
@@ -1501,7 +1569,8 @@ public class JavaTreeParser extends TreeParser {
             break;
         }
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:200:37: ( classTopLevelScope )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:200:37: (
+        // classTopLevelScope )?
         int alt21 = 2;
         int LA21_0 = input.LA(1);
 
@@ -1510,7 +1579,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt21) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: classTopLevelScope
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+            // classTopLevelScope
             {
               pushFollow(FOLLOW_classTopLevelScope_in_enumConstant385);
               classTopLevelScope();
@@ -1538,7 +1608,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "enumConstant"
 
   // $ANTLR start "classTopLevelScope"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:203:1: classTopLevelScope : ^( CLASS_TOP_LEVEL_SCOPE (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:203:1: classTopLevelScope :
+  // ^( CLASS_TOP_LEVEL_SCOPE (
   // classScopeDeclarations )* ) ;
   public final void classTopLevelScope() throws RecognitionException {
     int classTopLevelScope_StartIndex = input.index();
@@ -1546,9 +1617,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 12)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:204:3: ( ^( CLASS_TOP_LEVEL_SCOPE (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:204:3: ( ^(
+      // CLASS_TOP_LEVEL_SCOPE (
       // classScopeDeclarations )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:205:3: ^( CLASS_TOP_LEVEL_SCOPE (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:205:3: ^(
+      // CLASS_TOP_LEVEL_SCOPE (
       // classScopeDeclarations )* )
       {
         match(input, CLASS_TOP_LEVEL_SCOPE, FOLLOW_CLASS_TOP_LEVEL_SCOPE_in_classTopLevelScope403);
@@ -1557,7 +1630,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:205:27: ( classScopeDeclarations )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:205:27: (
+          // classScopeDeclarations )*
           loop22:
           do {
             int alt22 = 2;
@@ -1577,7 +1651,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt22) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: classScopeDeclarations
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // classScopeDeclarations
                 {
                   pushFollow(FOLLOW_classScopeDeclarations_in_classTopLevelScope405);
                   classScopeDeclarations();
@@ -1610,11 +1685,16 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "classTopLevelScope"
 
   // $ANTLR start "classScopeDeclarations"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:208:1: classScopeDeclarations : ( ^(
-  // CLASS_INSTANCE_INITIALIZER block ) | ^( CLASS_STATIC_INITIALIZER block ) | ^( FUNCTION_METHOD_DECL modifierList (
-  // genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block )? ) | ^(
-  // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block )? ) | ^(
-  // VAR_DECLARATION modifierList type variableDeclaratorList ) | ^( CONSTRUCTOR_DECL modifierList ( genericTypeParameterList )?
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:208:1:
+  // classScopeDeclarations : ( ^(
+  // CLASS_INSTANCE_INITIALIZER block ) | ^( CLASS_STATIC_INITIALIZER block ) | ^(
+  // FUNCTION_METHOD_DECL modifierList (
+  // genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? (
+  // throwsClause )? ( block )? ) | ^(
+  // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList (
+  // throwsClause )? ( block )? ) | ^(
+  // VAR_DECLARATION modifierList type variableDeclaratorList ) | ^( CONSTRUCTOR_DECL modifierList (
+  // genericTypeParameterList )?
   // formalParameterList ( throwsClause )? block ) | typeDeclaration );
   public final void classScopeDeclarations() throws RecognitionException {
     int classScopeDeclarations_StartIndex = input.index();
@@ -1622,11 +1702,16 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 13)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:209:3: ( ^( CLASS_INSTANCE_INITIALIZER block ) |
-      // ^( CLASS_STATIC_INITIALIZER block ) | ^( FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT
-      // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block )? ) | ^( VOID_METHOD_DECL modifierList (
-      // genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block )? ) | ^( VAR_DECLARATION modifierList
-      // type variableDeclaratorList ) | ^( CONSTRUCTOR_DECL modifierList ( genericTypeParameterList )? formalParameterList (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:209:3: ( ^(
+      // CLASS_INSTANCE_INITIALIZER block ) |
+      // ^( CLASS_STATIC_INITIALIZER block ) | ^( FUNCTION_METHOD_DECL modifierList (
+      // genericTypeParameterList )? type IDENT
+      // formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ( block )? ) | ^(
+      // VOID_METHOD_DECL modifierList (
+      // genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block )? ) | ^(
+      // VAR_DECLARATION modifierList
+      // type variableDeclaratorList ) | ^( CONSTRUCTOR_DECL modifierList ( genericTypeParameterList
+      // )? formalParameterList (
       // throwsClause )? block ) | typeDeclaration )
       int alt32 = 7;
       switch (input.LA(1)) {
@@ -1680,7 +1765,8 @@ public class JavaTreeParser extends TreeParser {
 
       switch (alt32) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:210:3: ^( CLASS_INSTANCE_INITIALIZER
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:210:3: ^(
+          // CLASS_INSTANCE_INITIALIZER
           // block )
           {
             match(
@@ -1702,7 +1788,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:212:3: ^( CLASS_STATIC_INITIALIZER block )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:212:3: ^(
+          // CLASS_STATIC_INITIALIZER block )
           {
             match(
                 input,
@@ -1723,8 +1810,10 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:3: ^( FUNCTION_METHOD_DECL
-          // modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:3: ^(
+          // FUNCTION_METHOD_DECL
+          // modifierList ( genericTypeParameterList )? type IDENT formalParameterList (
+          // arrayDeclaratorList )? ( throwsClause
           // )? ( block )? )
           {
             match(
@@ -1740,7 +1829,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:39: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:39: (
+            // genericTypeParameterList )?
             int alt23 = 2;
             int LA23_0 = input.LA(1);
 
@@ -1749,7 +1839,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt23) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_classScopeDeclarations451);
                   genericTypeParameterList();
@@ -1772,7 +1863,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:96: ( arrayDeclaratorList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:96: (
+            // arrayDeclaratorList )?
             int alt24 = 2;
             int LA24_0 = input.LA(1);
 
@@ -1781,7 +1873,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt24) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: arrayDeclaratorList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // arrayDeclaratorList
                 {
                   pushFollow(FOLLOW_arrayDeclaratorList_in_classScopeDeclarations460);
                   arrayDeclaratorList();
@@ -1792,7 +1885,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:117: ( throwsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:117: (
+            // throwsClause )?
             int alt25 = 2;
             int LA25_0 = input.LA(1);
 
@@ -1801,7 +1895,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt25) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: throwsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // throwsClause
                 {
                   pushFollow(FOLLOW_throwsClause_in_classScopeDeclarations463);
                   throwsClause();
@@ -1812,7 +1907,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:131: ( block )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:214:131: ( block
+            // )?
             int alt26 = 2;
             int LA26_0 = input.LA(1);
 
@@ -1837,7 +1933,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:216:3: ^( VOID_METHOD_DECL modifierList
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:216:3: ^(
+          // VOID_METHOD_DECL modifierList
           // ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ( block )? )
           {
             match(input, VOID_METHOD_DECL, FOLLOW_VOID_METHOD_DECL_in_classScopeDeclarations477);
@@ -1850,7 +1947,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:216:35: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:216:35: (
+            // genericTypeParameterList )?
             int alt27 = 2;
             int LA27_0 = input.LA(1);
 
@@ -1859,7 +1957,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt27) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_classScopeDeclarations481);
                   genericTypeParameterList();
@@ -1877,7 +1976,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:216:87: ( throwsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:216:87: (
+            // throwsClause )?
             int alt28 = 2;
             int LA28_0 = input.LA(1);
 
@@ -1886,7 +1986,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt28) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: throwsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // throwsClause
                 {
                   pushFollow(FOLLOW_throwsClause_in_classScopeDeclarations488);
                   throwsClause();
@@ -1897,7 +1998,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:216:101: ( block )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:216:101: ( block
+            // )?
             int alt29 = 2;
             int LA29_0 = input.LA(1);
 
@@ -1922,7 +2024,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 5:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:218:3: ^( VAR_DECLARATION modifierList
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:218:3: ^(
+          // VAR_DECLARATION modifierList
           // type variableDeclaratorList )
           {
             match(input, VAR_DECLARATION, FOLLOW_VAR_DECLARATION_in_classScopeDeclarations502);
@@ -1951,7 +2054,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 6:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:220:3: ^( CONSTRUCTOR_DECL modifierList
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:220:3: ^(
+          // CONSTRUCTOR_DECL modifierList
           // ( genericTypeParameterList )? formalParameterList ( throwsClause )? block )
           {
             match(input, CONSTRUCTOR_DECL, FOLLOW_CONSTRUCTOR_DECL_in_classScopeDeclarations518);
@@ -1964,7 +2068,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:220:35: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:220:35: (
+            // genericTypeParameterList )?
             int alt30 = 2;
             int LA30_0 = input.LA(1);
 
@@ -1973,7 +2078,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt30) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_classScopeDeclarations522);
                   genericTypeParameterList();
@@ -1989,7 +2095,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:220:81: ( throwsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:220:81: (
+            // throwsClause )?
             int alt31 = 2;
             int LA31_0 = input.LA(1);
 
@@ -1998,7 +2105,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt31) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: throwsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // throwsClause
                 {
                   pushFollow(FOLLOW_throwsClause_in_classScopeDeclarations527);
                   throwsClause();
@@ -2020,7 +2128,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 7:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:221:5: typeDeclaration
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:221:5:
+          // typeDeclaration
           {
             pushFollow(FOLLOW_typeDeclaration_in_classScopeDeclarations537);
             typeDeclaration();
@@ -2043,7 +2152,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "classScopeDeclarations"
 
   // $ANTLR start "interfaceTopLevelScope"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:224:1: interfaceTopLevelScope : ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:224:1:
+  // interfaceTopLevelScope : ^(
   // INTERFACE_TOP_LEVEL_SCOPE ( interfaceScopeDeclarations )* ) ;
   public final void interfaceTopLevelScope() throws RecognitionException {
     int interfaceTopLevelScope_StartIndex = input.index();
@@ -2051,9 +2161,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 14)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:225:3: ( ^( INTERFACE_TOP_LEVEL_SCOPE (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:225:3: ( ^(
+      // INTERFACE_TOP_LEVEL_SCOPE (
       // interfaceScopeDeclarations )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:226:3: ^( INTERFACE_TOP_LEVEL_SCOPE (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:226:3: ^(
+      // INTERFACE_TOP_LEVEL_SCOPE (
       // interfaceScopeDeclarations )* )
       {
         match(
@@ -2065,7 +2177,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:226:31: ( interfaceScopeDeclarations )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:226:31: (
+          // interfaceScopeDeclarations )*
           loop33:
           do {
             int alt33 = 2;
@@ -2083,7 +2196,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt33) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: interfaceScopeDeclarations
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // interfaceScopeDeclarations
                 {
                   pushFollow(FOLLOW_interfaceScopeDeclarations_in_interfaceTopLevelScope555);
                   interfaceScopeDeclarations();
@@ -2116,9 +2230,12 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "interfaceTopLevelScope"
 
   // $ANTLR start "interfaceScopeDeclarations"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:229:1: interfaceScopeDeclarations : ( ^(
-  // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? (
-  // throwsClause )? ) | ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ) |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:229:1:
+  // interfaceScopeDeclarations : ( ^(
+  // FUNCTION_METHOD_DECL modifierList ( genericTypeParameterList )? type IDENT formalParameterList
+  // ( arrayDeclaratorList )? (
+  // throwsClause )? ) | ^( VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT
+  // formalParameterList ( throwsClause )? ) |
   // ^( VAR_DECLARATION modifierList type variableDeclaratorList ) | typeDeclaration );
   public final void interfaceScopeDeclarations() throws RecognitionException {
     int interfaceScopeDeclarations_StartIndex = input.index();
@@ -2126,9 +2243,12 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 15)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:230:3: ( ^( FUNCTION_METHOD_DECL modifierList (
-      // genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause )? ) | ^(
-      // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? ) | ^(
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:230:3: ( ^(
+      // FUNCTION_METHOD_DECL modifierList (
+      // genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? (
+      // throwsClause )? ) | ^(
+      // VOID_METHOD_DECL modifierList ( genericTypeParameterList )? IDENT formalParameterList (
+      // throwsClause )? ) | ^(
       // VAR_DECLARATION modifierList type variableDeclaratorList ) | typeDeclaration )
       int alt39 = 4;
       switch (input.LA(1)) {
@@ -2167,8 +2287,10 @@ public class JavaTreeParser extends TreeParser {
 
       switch (alt39) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:231:3: ^( FUNCTION_METHOD_DECL
-          // modifierList ( genericTypeParameterList )? type IDENT formalParameterList ( arrayDeclaratorList )? ( throwsClause
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:231:3: ^(
+          // FUNCTION_METHOD_DECL
+          // modifierList ( genericTypeParameterList )? type IDENT formalParameterList (
+          // arrayDeclaratorList )? ( throwsClause
           // )? )
           {
             match(
@@ -2184,7 +2306,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:231:39: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:231:39: (
+            // genericTypeParameterList )?
             int alt34 = 2;
             int LA34_0 = input.LA(1);
 
@@ -2193,7 +2316,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt34) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_interfaceScopeDeclarations577);
                   genericTypeParameterList();
@@ -2216,7 +2340,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:231:96: ( arrayDeclaratorList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:231:96: (
+            // arrayDeclaratorList )?
             int alt35 = 2;
             int LA35_0 = input.LA(1);
 
@@ -2225,7 +2350,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt35) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: arrayDeclaratorList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // arrayDeclaratorList
                 {
                   pushFollow(FOLLOW_arrayDeclaratorList_in_interfaceScopeDeclarations586);
                   arrayDeclaratorList();
@@ -2236,7 +2362,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:231:117: ( throwsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:231:117: (
+            // throwsClause )?
             int alt36 = 2;
             int LA36_0 = input.LA(1);
 
@@ -2245,7 +2372,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt36) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: throwsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // throwsClause
                 {
                   pushFollow(FOLLOW_throwsClause_in_interfaceScopeDeclarations589);
                   throwsClause();
@@ -2261,7 +2389,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:233:3: ^( VOID_METHOD_DECL modifierList
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:233:3: ^(
+          // VOID_METHOD_DECL modifierList
           // ( genericTypeParameterList )? IDENT formalParameterList ( throwsClause )? )
           {
             match(
@@ -2275,7 +2404,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:233:35: ( genericTypeParameterList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:233:35: (
+            // genericTypeParameterList )?
             int alt37 = 2;
             int LA37_0 = input.LA(1);
 
@@ -2284,7 +2414,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt37) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeParameterList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeParameterList
                 {
                   pushFollow(FOLLOW_genericTypeParameterList_in_interfaceScopeDeclarations604);
                   genericTypeParameterList();
@@ -2302,7 +2433,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:233:87: ( throwsClause )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:233:87: (
+            // throwsClause )?
             int alt38 = 2;
             int LA38_0 = input.LA(1);
 
@@ -2311,7 +2443,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt38) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: throwsClause
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // throwsClause
                 {
                   pushFollow(FOLLOW_throwsClause_in_interfaceScopeDeclarations611);
                   throwsClause();
@@ -2327,7 +2460,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:238:3: ^( VAR_DECLARATION modifierList
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:238:3: ^(
+          // VAR_DECLARATION modifierList
           // type variableDeclaratorList )
           {
             match(input, VAR_DECLARATION, FOLLOW_VAR_DECLARATION_in_interfaceScopeDeclarations631);
@@ -2356,7 +2490,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:239:5: typeDeclaration
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:239:5:
+          // typeDeclaration
           {
             pushFollow(FOLLOW_typeDeclaration_in_interfaceScopeDeclarations644);
             typeDeclaration();
@@ -2379,7 +2514,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "interfaceScopeDeclarations"
 
   // $ANTLR start "variableDeclaratorList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:242:1: variableDeclaratorList : ^( VAR_DECLARATOR_LIST (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:242:1:
+  // variableDeclaratorList : ^( VAR_DECLARATOR_LIST (
   // variableDeclarator )+ ) ;
   public final void variableDeclaratorList() throws RecognitionException {
     int variableDeclaratorList_StartIndex = input.index();
@@ -2387,9 +2523,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 16)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:243:3: ( ^( VAR_DECLARATOR_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:243:3: ( ^(
+      // VAR_DECLARATOR_LIST (
       // variableDeclarator )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:244:3: ^( VAR_DECLARATOR_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:244:3: ^(
+      // VAR_DECLARATOR_LIST (
       // variableDeclarator )+ )
       {
         match(input, VAR_DECLARATOR_LIST, FOLLOW_VAR_DECLARATOR_LIST_in_variableDeclaratorList660);
@@ -2397,7 +2535,8 @@ public class JavaTreeParser extends TreeParser {
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:244:25: ( variableDeclarator )+
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:244:25: (
+        // variableDeclarator )+
         int cnt40 = 0;
         loop40:
         do {
@@ -2410,7 +2549,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt40) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: variableDeclarator
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // variableDeclarator
               {
                 pushFollow(FOLLOW_variableDeclarator_in_variableDeclaratorList662);
                 variableDeclarator();
@@ -2449,7 +2589,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "variableDeclaratorList"
 
   // $ANTLR start "variableDeclarator"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:247:1: variableDeclarator : ^( VAR_DECLARATOR
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:247:1: variableDeclarator :
+  // ^( VAR_DECLARATOR
   // variableDeclaratorId ( variableInitializer )? ) ;
   public final void variableDeclarator() throws RecognitionException {
     int variableDeclarator_StartIndex = input.index();
@@ -2457,9 +2598,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 17)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:248:3: ( ^( VAR_DECLARATOR variableDeclaratorId
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:248:3: ( ^(
+      // VAR_DECLARATOR variableDeclaratorId
       // ( variableInitializer )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:249:3: ^( VAR_DECLARATOR variableDeclaratorId (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:249:3: ^(
+      // VAR_DECLARATOR variableDeclaratorId (
       // variableInitializer )? )
       {
         match(input, VAR_DECLARATOR, FOLLOW_VAR_DECLARATOR_in_variableDeclarator680);
@@ -2472,7 +2615,8 @@ public class JavaTreeParser extends TreeParser {
 
         state._fsp--;
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:249:41: ( variableInitializer )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:249:41: (
+        // variableInitializer )?
         int alt41 = 2;
         int LA41_0 = input.LA(1);
 
@@ -2481,7 +2625,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt41) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: variableInitializer
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+            // variableInitializer
             {
               pushFollow(FOLLOW_variableInitializer_in_variableDeclarator684);
               variableInitializer();
@@ -2509,7 +2654,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "variableDeclarator"
 
   // $ANTLR start "variableDeclaratorId"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:252:1: variableDeclaratorId : ^( IDENT (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:252:1: variableDeclaratorId
+  // : ^( IDENT (
   // arrayDeclaratorList )? ) ;
   public final void variableDeclaratorId() throws RecognitionException {
     int variableDeclaratorId_StartIndex = input.index();
@@ -2517,8 +2663,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 18)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:253:3: ( ^( IDENT ( arrayDeclaratorList )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:254:3: ^( IDENT ( arrayDeclaratorList )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:253:3: ( ^( IDENT (
+      // arrayDeclaratorList )? ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:254:3: ^( IDENT (
+      // arrayDeclaratorList )? )
       {
         match(input, IDENT, FOLLOW_IDENT_in_variableDeclaratorId702);
         if (state.failed) return;
@@ -2526,7 +2674,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:254:11: ( arrayDeclaratorList )?
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:254:11: (
+          // arrayDeclaratorList )?
           int alt42 = 2;
           int LA42_0 = input.LA(1);
 
@@ -2535,7 +2684,8 @@ public class JavaTreeParser extends TreeParser {
           }
           switch (alt42) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: arrayDeclaratorList
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // arrayDeclaratorList
               {
                 pushFollow(FOLLOW_arrayDeclaratorList_in_variableDeclaratorId704);
                 arrayDeclaratorList();
@@ -2564,7 +2714,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "variableDeclaratorId"
 
   // $ANTLR start "variableInitializer"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:257:1: variableInitializer : ( arrayInitializer |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:257:1: variableInitializer
+  // : ( arrayInitializer |
   // expression );
   public final void variableInitializer() throws RecognitionException {
     int variableInitializer_StartIndex = input.index();
@@ -2572,7 +2723,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 19)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:258:3: ( arrayInitializer | expression )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:258:3: (
+      // arrayInitializer | expression )
       int alt43 = 2;
       int LA43_0 = input.LA(1);
 
@@ -2591,7 +2743,8 @@ public class JavaTreeParser extends TreeParser {
       }
       switch (alt43) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:259:3: arrayInitializer
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:259:3:
+          // arrayInitializer
           {
             pushFollow(FOLLOW_arrayInitializer_in_variableInitializer721);
             arrayInitializer();
@@ -2624,14 +2777,16 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "variableInitializer"
 
   // $ANTLR start "arrayDeclarator"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:263:1: arrayDeclarator : LBRACK RBRACK ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:263:1: arrayDeclarator :
+  // LBRACK RBRACK ;
   public final void arrayDeclarator() throws RecognitionException {
     int arrayDeclarator_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 20)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:264:3: ( LBRACK RBRACK )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:264:3: ( LBRACK RBRACK
+      // )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:265:3: LBRACK RBRACK
       {
         match(input, LBRACK, FOLLOW_LBRACK_in_arrayDeclarator742);
@@ -2653,7 +2808,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "arrayDeclarator"
 
   // $ANTLR start "arrayDeclaratorList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:268:1: arrayDeclaratorList : ^( ARRAY_DECLARATOR_LIST (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:268:1: arrayDeclaratorList
+  // : ^( ARRAY_DECLARATOR_LIST (
   // ARRAY_DECLARATOR )* ) ;
   public final void arrayDeclaratorList() throws RecognitionException {
     int arrayDeclaratorList_StartIndex = input.index();
@@ -2661,9 +2817,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 21)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:269:3: ( ^( ARRAY_DECLARATOR_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:269:3: ( ^(
+      // ARRAY_DECLARATOR_LIST (
       // ARRAY_DECLARATOR )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:270:3: ^( ARRAY_DECLARATOR_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:270:3: ^(
+      // ARRAY_DECLARATOR_LIST (
       // ARRAY_DECLARATOR )* )
       {
         match(input, ARRAY_DECLARATOR_LIST, FOLLOW_ARRAY_DECLARATOR_LIST_in_arrayDeclaratorList760);
@@ -2672,7 +2830,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:270:27: ( ARRAY_DECLARATOR )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:270:27: (
+          // ARRAY_DECLARATOR )*
           loop44:
           do {
             int alt44 = 2;
@@ -2684,7 +2843,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt44) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: ARRAY_DECLARATOR
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // ARRAY_DECLARATOR
                 {
                   match(input, ARRAY_DECLARATOR, FOLLOW_ARRAY_DECLARATOR_in_arrayDeclaratorList762);
                   if (state.failed) return;
@@ -2714,7 +2874,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "arrayDeclaratorList"
 
   // $ANTLR start "arrayInitializer"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:273:1: arrayInitializer : ^( ARRAY_INITIALIZER (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:273:1: arrayInitializer :
+  // ^( ARRAY_INITIALIZER (
   // variableInitializer )* ) ;
   public final void arrayInitializer() throws RecognitionException {
     int arrayInitializer_StartIndex = input.index();
@@ -2722,9 +2883,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 22)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:274:3: ( ^( ARRAY_INITIALIZER (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:274:3: ( ^(
+      // ARRAY_INITIALIZER (
       // variableInitializer )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:275:3: ^( ARRAY_INITIALIZER (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:275:3: ^(
+      // ARRAY_INITIALIZER (
       // variableInitializer )* )
       {
         match(input, ARRAY_INITIALIZER, FOLLOW_ARRAY_INITIALIZER_in_arrayInitializer780);
@@ -2733,7 +2896,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:275:23: ( variableInitializer )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:275:23: (
+          // variableInitializer )*
           loop45:
           do {
             int alt45 = 2;
@@ -2745,7 +2909,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt45) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: variableInitializer
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // variableInitializer
                 {
                   pushFollow(FOLLOW_variableInitializer_in_arrayInitializer782);
                   variableInitializer();
@@ -2778,7 +2943,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "arrayInitializer"
 
   // $ANTLR start "throwsClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:278:1: throwsClause : ^( THROWS_CLAUSE (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:278:1: throwsClause : ^(
+  // THROWS_CLAUSE (
   // qualifiedIdentifier )+ ) ;
   public final void throwsClause() throws RecognitionException {
     int throwsClause_StartIndex = input.index();
@@ -2786,16 +2952,19 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 23)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:279:3: ( ^( THROWS_CLAUSE ( qualifiedIdentifier
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:279:3: ( ^(
+      // THROWS_CLAUSE ( qualifiedIdentifier
       // )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:280:3: ^( THROWS_CLAUSE ( qualifiedIdentifier )+ )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:280:3: ^( THROWS_CLAUSE
+      // ( qualifiedIdentifier )+ )
       {
         match(input, THROWS_CLAUSE, FOLLOW_THROWS_CLAUSE_in_throwsClause800);
         if (state.failed) return;
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:280:19: ( qualifiedIdentifier )+
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:280:19: (
+        // qualifiedIdentifier )+
         int cnt46 = 0;
         loop46:
         do {
@@ -2808,7 +2977,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt46) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: qualifiedIdentifier
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // qualifiedIdentifier
               {
                 pushFollow(FOLLOW_qualifiedIdentifier_in_throwsClause802);
                 qualifiedIdentifier();
@@ -2847,15 +3017,18 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "throwsClause"
 
   // $ANTLR start "modifierList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:283:1: modifierList : ^( MODIFIER_LIST ( modifier )* ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:283:1: modifierList : ^(
+  // MODIFIER_LIST ( modifier )* ) ;
   public final void modifierList() throws RecognitionException {
     int modifierList_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 24)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:284:3: ( ^( MODIFIER_LIST ( modifier )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:285:3: ^( MODIFIER_LIST ( modifier )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:284:3: ( ^(
+      // MODIFIER_LIST ( modifier )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:285:3: ^( MODIFIER_LIST
+      // ( modifier )* )
       {
         match(input, MODIFIER_LIST, FOLLOW_MODIFIER_LIST_in_modifierList820);
         if (state.failed) return;
@@ -2863,7 +3036,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:285:19: ( modifier )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:285:19: ( modifier
+          // )*
           loop47:
           do {
             int alt47 = 2;
@@ -2916,7 +3090,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "modifierList"
 
   // $ANTLR start "modifier"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:288:1: modifier : ( PUBLIC | PROTECTED | PRIVATE |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:288:1: modifier : ( PUBLIC
+  // | PROTECTED | PRIVATE |
   // STATIC | ABSTRACT | NATIVE | SYNCHRONIZED | TRANSIENT | VOLATILE | STRICTFP | localModifier );
   public final void modifier() throws RecognitionException {
     int modifier_StartIndex = input.index();
@@ -2924,7 +3099,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 25)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:289:3: ( PUBLIC | PROTECTED | PRIVATE | STATIC |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:289:3: ( PUBLIC |
+      // PROTECTED | PRIVATE | STATIC |
       // ABSTRACT | NATIVE | SYNCHRONIZED | TRANSIENT | VOLATILE | STRICTFP | localModifier )
       int alt48 = 11;
       switch (input.LA(1)) {
@@ -3066,7 +3242,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 11:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:300:5: localModifier
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:300:5:
+          // localModifier
           {
             pushFollow(FOLLOW_localModifier_in_modifier899);
             localModifier();
@@ -3089,7 +3266,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "modifier"
 
   // $ANTLR start "localModifierList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:303:1: localModifierList : ^( LOCAL_MODIFIER_LIST (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:303:1: localModifierList :
+  // ^( LOCAL_MODIFIER_LIST (
   // localModifier )* ) ;
   public final void localModifierList() throws RecognitionException {
     int localModifierList_StartIndex = input.index();
@@ -3097,9 +3275,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 26)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:304:3: ( ^( LOCAL_MODIFIER_LIST ( localModifier
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:304:3: ( ^(
+      // LOCAL_MODIFIER_LIST ( localModifier
       // )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:305:3: ^( LOCAL_MODIFIER_LIST ( localModifier )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:305:3: ^(
+      // LOCAL_MODIFIER_LIST ( localModifier )* )
       {
         match(input, LOCAL_MODIFIER_LIST, FOLLOW_LOCAL_MODIFIER_LIST_in_localModifierList915);
         if (state.failed) return;
@@ -3107,7 +3287,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:305:25: ( localModifier )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:305:25: (
+          // localModifier )*
           loop49:
           do {
             int alt49 = 2;
@@ -3119,7 +3300,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt49) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: localModifier
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // localModifier
                 {
                   pushFollow(FOLLOW_localModifier_in_localModifierList917);
                   localModifier();
@@ -3152,14 +3334,16 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "localModifierList"
 
   // $ANTLR start "localModifier"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:308:1: localModifier : ( FINAL | annotation );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:308:1: localModifier : (
+  // FINAL | annotation );
   public final void localModifier() throws RecognitionException {
     int localModifier_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 27)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:309:3: ( FINAL | annotation )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:309:3: ( FINAL |
+      // annotation )
       int alt50 = 2;
       int LA50_0 = input.LA(1);
 
@@ -3208,7 +3392,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "localModifier"
 
   // $ANTLR start "type"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:314:1: type : ^( TYPE ( primitiveType |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:314:1: type : ^( TYPE (
+  // primitiveType |
   // qualifiedTypeIdent ) ( arrayDeclaratorList )? ) ;
   public final void type() throws RecognitionException {
     int type_StartIndex = input.index();
@@ -3216,9 +3401,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 28)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:315:3: ( ^( TYPE ( primitiveType |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:315:3: ( ^( TYPE (
+      // primitiveType |
       // qualifiedTypeIdent ) ( arrayDeclaratorList )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:316:3: ^( TYPE ( primitiveType |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:316:3: ^( TYPE (
+      // primitiveType |
       // qualifiedTypeIdent ) ( arrayDeclaratorList )? )
       {
         match(input, TYPE, FOLLOW_TYPE_in_type961);
@@ -3226,7 +3413,8 @@ public class JavaTreeParser extends TreeParser {
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:318:5: ( primitiveType | qualifiedTypeIdent )
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:318:5: (
+        // primitiveType | qualifiedTypeIdent )
         int alt51 = 2;
         int LA51_0 = input.LA(1);
 
@@ -3251,7 +3439,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt51) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:319:7: primitiveType
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:319:7:
+            // primitiveType
             {
               pushFollow(FOLLOW_primitiveType_in_type975);
               primitiveType();
@@ -3261,7 +3450,8 @@ public class JavaTreeParser extends TreeParser {
             }
             break;
           case 2:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:320:9: qualifiedTypeIdent
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:320:9:
+            // qualifiedTypeIdent
             {
               pushFollow(FOLLOW_qualifiedTypeIdent_in_type985);
               qualifiedTypeIdent();
@@ -3272,7 +3462,8 @@ public class JavaTreeParser extends TreeParser {
             break;
         }
 
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:322:5: ( arrayDeclaratorList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:322:5: (
+        // arrayDeclaratorList )?
         int alt52 = 2;
         int LA52_0 = input.LA(1);
 
@@ -3281,7 +3472,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt52) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: arrayDeclaratorList
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+            // arrayDeclaratorList
             {
               pushFollow(FOLLOW_arrayDeclaratorList_in_type997);
               arrayDeclaratorList();
@@ -3309,7 +3501,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "type"
 
   // $ANTLR start "qualifiedTypeIdent"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:326:1: qualifiedTypeIdent : ^( QUALIFIED_TYPE_IDENT (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:326:1: qualifiedTypeIdent :
+  // ^( QUALIFIED_TYPE_IDENT (
   // typeIdent )+ ) ;
   public final void qualifiedTypeIdent() throws RecognitionException {
     int qualifiedTypeIdent_StartIndex = input.index();
@@ -3317,15 +3510,18 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 29)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:327:3: ( ^( QUALIFIED_TYPE_IDENT ( typeIdent )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:328:3: ^( QUALIFIED_TYPE_IDENT ( typeIdent )+ )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:327:3: ( ^(
+      // QUALIFIED_TYPE_IDENT ( typeIdent )+ ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:328:3: ^(
+      // QUALIFIED_TYPE_IDENT ( typeIdent )+ )
       {
         match(input, QUALIFIED_TYPE_IDENT, FOLLOW_QUALIFIED_TYPE_IDENT_in_qualifiedTypeIdent1019);
         if (state.failed) return;
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:328:26: ( typeIdent )+
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:328:26: ( typeIdent
+        // )+
         int cnt53 = 0;
         loop53:
         do {
@@ -3377,7 +3573,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "qualifiedTypeIdent"
 
   // $ANTLR start "typeIdent"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:331:1: typeIdent : ^( IDENT ( genericTypeArgumentList )?
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:331:1: typeIdent : ^( IDENT
+  // ( genericTypeArgumentList )?
   // ) ;
   public final void typeIdent() throws RecognitionException {
     int typeIdent_StartIndex = input.index();
@@ -3385,8 +3582,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 30)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:332:3: ( ^( IDENT ( genericTypeArgumentList )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:333:3: ^( IDENT ( genericTypeArgumentList )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:332:3: ( ^( IDENT (
+      // genericTypeArgumentList )? ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:333:3: ^( IDENT (
+      // genericTypeArgumentList )? )
       {
         match(input, IDENT, FOLLOW_IDENT_in_typeIdent1039);
         if (state.failed) return;
@@ -3394,7 +3593,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:333:11: ( genericTypeArgumentList )?
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:333:11: (
+          // genericTypeArgumentList )?
           int alt54 = 2;
           int LA54_0 = input.LA(1);
 
@@ -3403,7 +3603,8 @@ public class JavaTreeParser extends TreeParser {
           }
           switch (alt54) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeArgumentList
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // genericTypeArgumentList
               {
                 pushFollow(FOLLOW_genericTypeArgumentList_in_typeIdent1041);
                 genericTypeArgumentList();
@@ -3432,7 +3633,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "typeIdent"
 
   // $ANTLR start "primitiveType"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:336:1: primitiveType : ( BOOLEAN | CHAR | BYTE | SHORT |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:336:1: primitiveType : (
+  // BOOLEAN | CHAR | BYTE | SHORT |
   // INT | LONG | FLOAT | DOUBLE );
   public final void primitiveType() throws RecognitionException {
     int primitiveType_StartIndex = input.index();
@@ -3440,7 +3642,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 31)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:337:3: ( BOOLEAN | CHAR | BYTE | SHORT | INT |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:337:3: ( BOOLEAN | CHAR
+      // | BYTE | SHORT | INT |
       // LONG | FLOAT | DOUBLE )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:
       {
@@ -3477,7 +3680,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "primitiveType"
 
   // $ANTLR start "genericTypeArgumentList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:348:1: genericTypeArgumentList : ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:348:1:
+  // genericTypeArgumentList : ^(
   // GENERIC_TYPE_ARG_LIST ( genericTypeArgument )+ ) ;
   public final void genericTypeArgumentList() throws RecognitionException {
     int genericTypeArgumentList_StartIndex = input.index();
@@ -3485,9 +3689,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 32)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:349:3: ( ^( GENERIC_TYPE_ARG_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:349:3: ( ^(
+      // GENERIC_TYPE_ARG_LIST (
       // genericTypeArgument )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:350:3: ^( GENERIC_TYPE_ARG_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:350:3: ^(
+      // GENERIC_TYPE_ARG_LIST (
       // genericTypeArgument )+ )
       {
         match(
@@ -3498,7 +3704,8 @@ public class JavaTreeParser extends TreeParser {
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:350:27: ( genericTypeArgument )+
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:350:27: (
+        // genericTypeArgument )+
         int cnt55 = 0;
         loop55:
         do {
@@ -3511,7 +3718,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt55) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeArgument
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // genericTypeArgument
               {
                 pushFollow(FOLLOW_genericTypeArgument_in_genericTypeArgumentList1118);
                 genericTypeArgument();
@@ -3550,7 +3758,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "genericTypeArgumentList"
 
   // $ANTLR start "genericTypeArgument"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:353:1: genericTypeArgument : ( type | ^( QUESTION (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:353:1: genericTypeArgument
+  // : ( type | ^( QUESTION (
   // genericWildcardBoundType )? ) );
   public final void genericTypeArgument() throws RecognitionException {
     int genericTypeArgument_StartIndex = input.index();
@@ -3558,7 +3767,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 33)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:354:3: ( type | ^( QUESTION (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:354:3: ( type | ^(
+      // QUESTION (
       // genericWildcardBoundType )? ) )
       int alt57 = 2;
       int LA57_0 = input.LA(1);
@@ -3588,7 +3798,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:357:3: ^( QUESTION (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:357:3: ^( QUESTION
+          // (
           // genericWildcardBoundType )? )
           {
             match(input, QUESTION, FOLLOW_QUESTION_in_genericTypeArgument1144);
@@ -3597,7 +3808,8 @@ public class JavaTreeParser extends TreeParser {
             if (input.LA(1) == Token.DOWN) {
               match(input, Token.DOWN, null);
               if (state.failed) return;
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:357:14: ( genericWildcardBoundType )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:357:14: (
+              // genericWildcardBoundType )?
               int alt56 = 2;
               int LA56_0 = input.LA(1);
 
@@ -3606,7 +3818,8 @@ public class JavaTreeParser extends TreeParser {
               }
               switch (alt56) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericWildcardBoundType
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                  // genericWildcardBoundType
                   {
                     pushFollow(FOLLOW_genericWildcardBoundType_in_genericTypeArgument1146);
                     genericWildcardBoundType();
@@ -3636,7 +3849,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "genericTypeArgument"
 
   // $ANTLR start "genericWildcardBoundType"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:360:1: genericWildcardBoundType : ( ^( EXTENDS type ) |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:360:1:
+  // genericWildcardBoundType : ( ^( EXTENDS type ) |
   // ^( SUPER type ) );
   public final void genericWildcardBoundType() throws RecognitionException {
     int genericWildcardBoundType_StartIndex = input.index();
@@ -3644,7 +3858,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 34)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:361:3: ( ^( EXTENDS type ) | ^( SUPER type ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:361:3: ( ^( EXTENDS
+      // type ) | ^( SUPER type ) )
       int alt58 = 2;
       int LA58_0 = input.LA(1);
 
@@ -3663,7 +3878,8 @@ public class JavaTreeParser extends TreeParser {
       }
       switch (alt58) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:362:3: ^( EXTENDS type )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:362:3: ^( EXTENDS
+          // type )
           {
             match(input, EXTENDS, FOLLOW_EXTENDS_in_genericWildcardBoundType1164);
             if (state.failed) return;
@@ -3681,7 +3897,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:364:3: ^( SUPER type )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:364:3: ^( SUPER
+          // type )
           {
             match(input, SUPER, FOLLOW_SUPER_in_genericWildcardBoundType1176);
             if (state.failed) return;
@@ -3712,7 +3929,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "genericWildcardBoundType"
 
   // $ANTLR start "formalParameterList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:367:1: formalParameterList : ^( FORMAL_PARAM_LIST (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:367:1: formalParameterList
+  // : ^( FORMAL_PARAM_LIST (
   // formalParameterStandardDecl )* ( formalParameterVarargDecl )? ) ;
   public final void formalParameterList() throws RecognitionException {
     int formalParameterList_StartIndex = input.index();
@@ -3720,9 +3938,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 35)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:368:3: ( ^( FORMAL_PARAM_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:368:3: ( ^(
+      // FORMAL_PARAM_LIST (
       // formalParameterStandardDecl )* ( formalParameterVarargDecl )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:369:3: ^( FORMAL_PARAM_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:369:3: ^(
+      // FORMAL_PARAM_LIST (
       // formalParameterStandardDecl )* ( formalParameterVarargDecl )? )
       {
         match(input, FORMAL_PARAM_LIST, FOLLOW_FORMAL_PARAM_LIST_in_formalParameterList1195);
@@ -3731,7 +3951,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:369:23: ( formalParameterStandardDecl )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:369:23: (
+          // formalParameterStandardDecl )*
           loop59:
           do {
             int alt59 = 2;
@@ -3759,7 +3980,8 @@ public class JavaTreeParser extends TreeParser {
             }
           } while (true);
 
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:369:52: ( formalParameterVarargDecl )?
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:369:52: (
+          // formalParameterVarargDecl )?
           int alt60 = 2;
           int LA60_0 = input.LA(1);
 
@@ -3768,7 +3990,8 @@ public class JavaTreeParser extends TreeParser {
           }
           switch (alt60) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: formalParameterVarargDecl
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // formalParameterVarargDecl
               {
                 pushFollow(FOLLOW_formalParameterVarargDecl_in_formalParameterList1200);
                 formalParameterVarargDecl();
@@ -3797,7 +4020,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "formalParameterList"
 
   // $ANTLR start "formalParameterStandardDecl"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:372:1: formalParameterStandardDecl : ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:372:1:
+  // formalParameterStandardDecl : ^(
   // FORMAL_PARAM_STD_DECL localModifierList type variableDeclaratorId ) ;
   public final void formalParameterStandardDecl() throws RecognitionException {
     int formalParameterStandardDecl_StartIndex = input.index();
@@ -3805,9 +4029,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 36)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:373:3: ( ^( FORMAL_PARAM_STD_DECL
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:373:3: ( ^(
+      // FORMAL_PARAM_STD_DECL
       // localModifierList type variableDeclaratorId ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:374:3: ^( FORMAL_PARAM_STD_DECL
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:374:3: ^(
+      // FORMAL_PARAM_STD_DECL
       // localModifierList type variableDeclaratorId )
       {
         match(
@@ -3851,7 +4077,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "formalParameterStandardDecl"
 
   // $ANTLR start "formalParameterVarargDecl"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:377:1: formalParameterVarargDecl : ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:377:1:
+  // formalParameterVarargDecl : ^(
   // FORMAL_PARAM_VARARG_DECL localModifierList type variableDeclaratorId ) ;
   public final void formalParameterVarargDecl() throws RecognitionException {
     int formalParameterVarargDecl_StartIndex = input.index();
@@ -3859,9 +4086,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 37)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:378:3: ( ^( FORMAL_PARAM_VARARG_DECL
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:378:3: ( ^(
+      // FORMAL_PARAM_VARARG_DECL
       // localModifierList type variableDeclaratorId ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:379:3: ^( FORMAL_PARAM_VARARG_DECL
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:379:3: ^(
+      // FORMAL_PARAM_VARARG_DECL
       // localModifierList type variableDeclaratorId )
       {
         match(
@@ -3905,7 +4134,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "formalParameterVarargDecl"
 
   // $ANTLR start "qualifiedIdentifier"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:382:1: qualifiedIdentifier : ( IDENT | ^( DOT
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:382:1: qualifiedIdentifier
+  // : ( IDENT | ^( DOT
   // qualifiedIdentifier IDENT ) );
   public final void qualifiedIdentifier() throws RecognitionException {
     int qualifiedIdentifier_StartIndex = input.index();
@@ -3913,7 +4143,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 38)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:383:3: ( IDENT | ^( DOT qualifiedIdentifier
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:383:3: ( IDENT | ^( DOT
+      // qualifiedIdentifier
       // IDENT ) )
       int alt61 = 2;
       int LA61_0 = input.LA(1);
@@ -3940,7 +4171,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:386:3: ^( DOT qualifiedIdentifier IDENT )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:386:3: ^( DOT
+          // qualifiedIdentifier IDENT )
           {
             match(input, DOT, FOLLOW_DOT_in_qualifiedIdentifier1272);
             if (state.failed) return;
@@ -3973,7 +4205,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "qualifiedIdentifier"
 
   // $ANTLR start "annotationList"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:391:1: annotationList : ^( ANNOTATION_LIST ( annotation
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:391:1: annotationList : ^(
+  // ANNOTATION_LIST ( annotation
   // )* ) ;
   public final void annotationList() throws RecognitionException {
     int annotationList_StartIndex = input.index();
@@ -3981,8 +4214,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 39)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:392:3: ( ^( ANNOTATION_LIST ( annotation )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:393:3: ^( ANNOTATION_LIST ( annotation )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:392:3: ( ^(
+      // ANNOTATION_LIST ( annotation )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:393:3: ^(
+      // ANNOTATION_LIST ( annotation )* )
       {
         match(input, ANNOTATION_LIST, FOLLOW_ANNOTATION_LIST_in_annotationList1295);
         if (state.failed) return;
@@ -3990,7 +4225,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:393:21: ( annotation )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:393:21: (
+          // annotation )*
           loop62:
           do {
             int alt62 = 2;
@@ -4002,7 +4238,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt62) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: annotation
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // annotation
                 {
                   pushFollow(FOLLOW_annotation_in_annotationList1297);
                   annotation();
@@ -4035,7 +4272,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotationList"
 
   // $ANTLR start "annotation"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:396:1: annotation : ^( AT qualifiedIdentifier (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:396:1: annotation : ^( AT
+  // qualifiedIdentifier (
   // annotationInit )? ) ;
   public final void annotation() throws RecognitionException {
     int annotation_StartIndex = input.index();
@@ -4043,9 +4281,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 40)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:397:3: ( ^( AT qualifiedIdentifier (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:397:3: ( ^( AT
+      // qualifiedIdentifier (
       // annotationInit )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:398:3: ^( AT qualifiedIdentifier (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:398:3: ^( AT
+      // qualifiedIdentifier (
       // annotationInit )? )
       {
         match(input, AT, FOLLOW_AT_in_annotation1315);
@@ -4058,7 +4298,8 @@ public class JavaTreeParser extends TreeParser {
 
         state._fsp--;
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:398:28: ( annotationInit )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:398:28: (
+        // annotationInit )?
         int alt63 = 2;
         int LA63_0 = input.LA(1);
 
@@ -4067,7 +4308,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt63) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: annotationInit
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+            // annotationInit
             {
               pushFollow(FOLLOW_annotationInit_in_annotation1319);
               annotationInit();
@@ -4095,7 +4337,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotation"
 
   // $ANTLR start "annotationInit"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:401:1: annotationInit : ^( ANNOTATION_INIT_BLOCK
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:401:1: annotationInit : ^(
+  // ANNOTATION_INIT_BLOCK
   // annotationInitializers ) ;
   public final void annotationInit() throws RecognitionException {
     int annotationInit_StartIndex = input.index();
@@ -4103,9 +4346,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 41)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:402:3: ( ^( ANNOTATION_INIT_BLOCK
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:402:3: ( ^(
+      // ANNOTATION_INIT_BLOCK
       // annotationInitializers ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:403:3: ^( ANNOTATION_INIT_BLOCK
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:403:3: ^(
+      // ANNOTATION_INIT_BLOCK
       // annotationInitializers )
       {
         match(input, ANNOTATION_INIT_BLOCK, FOLLOW_ANNOTATION_INIT_BLOCK_in_annotationInit1337);
@@ -4136,15 +4381,18 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotationInit"
 
   // $ANTLR start "annotationInitializers"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:406:1: annotationInitializers : ( ^(
-  // ANNOTATION_INIT_KEY_LIST ( annotationInitializer )+ ) | ^( ANNOTATION_INIT_DEFAULT_KEY annotationElementValue ) );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:406:1:
+  // annotationInitializers : ( ^(
+  // ANNOTATION_INIT_KEY_LIST ( annotationInitializer )+ ) | ^( ANNOTATION_INIT_DEFAULT_KEY
+  // annotationElementValue ) );
   public final void annotationInitializers() throws RecognitionException {
     int annotationInitializers_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 42)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:407:3: ( ^( ANNOTATION_INIT_KEY_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:407:3: ( ^(
+      // ANNOTATION_INIT_KEY_LIST (
       // annotationInitializer )+ ) | ^( ANNOTATION_INIT_DEFAULT_KEY annotationElementValue ) )
       int alt65 = 2;
       int LA65_0 = input.LA(1);
@@ -4164,7 +4412,8 @@ public class JavaTreeParser extends TreeParser {
       }
       switch (alt65) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:408:3: ^( ANNOTATION_INIT_KEY_LIST (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:408:3: ^(
+          // ANNOTATION_INIT_KEY_LIST (
           // annotationInitializer )+ )
           {
             match(
@@ -4175,7 +4424,8 @@ public class JavaTreeParser extends TreeParser {
 
             match(input, Token.DOWN, null);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:408:30: ( annotationInitializer )+
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:408:30: (
+            // annotationInitializer )+
             int cnt64 = 0;
             loop64:
             do {
@@ -4188,7 +4438,8 @@ public class JavaTreeParser extends TreeParser {
 
               switch (alt64) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: annotationInitializer
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                  // annotationInitializer
                   {
                     pushFollow(FOLLOW_annotationInitializer_in_annotationInitializers1358);
                     annotationInitializer();
@@ -4215,7 +4466,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:410:3: ^( ANNOTATION_INIT_DEFAULT_KEY
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:410:3: ^(
+          // ANNOTATION_INIT_DEFAULT_KEY
           // annotationElementValue )
           {
             match(
@@ -4250,7 +4502,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotationInitializers"
 
   // $ANTLR start "annotationInitializer"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:413:1: annotationInitializer : ^( IDENT
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:413:1:
+  // annotationInitializer : ^( IDENT
   // annotationElementValue ) ;
   public final void annotationInitializer() throws RecognitionException {
     int annotationInitializer_StartIndex = input.index();
@@ -4258,8 +4511,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 43)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:414:3: ( ^( IDENT annotationElementValue ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:415:3: ^( IDENT annotationElementValue )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:414:3: ( ^( IDENT
+      // annotationElementValue ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:415:3: ^( IDENT
+      // annotationElementValue )
       {
         match(input, IDENT, FOLLOW_IDENT_in_annotationInitializer1388);
         if (state.failed) return;
@@ -4289,7 +4544,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotationInitializer"
 
   // $ANTLR start "annotationElementValue"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:418:1: annotationElementValue : ( ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:418:1:
+  // annotationElementValue : ( ^(
   // ANNOTATION_INIT_ARRAY_ELEMENT ( annotationElementValue )* ) | annotation | expression );
   public final void annotationElementValue() throws RecognitionException {
     int annotationElementValue_StartIndex = input.index();
@@ -4297,7 +4553,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 44)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:419:3: ( ^( ANNOTATION_INIT_ARRAY_ELEMENT (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:419:3: ( ^(
+      // ANNOTATION_INIT_ARRAY_ELEMENT (
       // annotationElementValue )* ) | annotation | expression )
       int alt67 = 3;
       switch (input.LA(1)) {
@@ -4328,7 +4585,8 @@ public class JavaTreeParser extends TreeParser {
 
       switch (alt67) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:420:3: ^( ANNOTATION_INIT_ARRAY_ELEMENT
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:420:3: ^(
+          // ANNOTATION_INIT_ARRAY_ELEMENT
           // ( annotationElementValue )* )
           {
             match(
@@ -4340,7 +4598,8 @@ public class JavaTreeParser extends TreeParser {
             if (input.LA(1) == Token.DOWN) {
               match(input, Token.DOWN, null);
               if (state.failed) return;
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:420:35: ( annotationElementValue )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:420:35: (
+              // annotationElementValue )*
               loop66:
               do {
                 int alt66 = 2;
@@ -4352,7 +4611,8 @@ public class JavaTreeParser extends TreeParser {
 
                 switch (alt66) {
                   case 1:
-                    // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: annotationElementValue
+                    // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                    // annotationElementValue
                     {
                       pushFollow(FOLLOW_annotationElementValue_in_annotationElementValue1409);
                       annotationElementValue();
@@ -4406,7 +4666,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotationElementValue"
 
   // $ANTLR start "annotationTopLevelScope"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:425:1: annotationTopLevelScope : ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:425:1:
+  // annotationTopLevelScope : ^(
   // ANNOTATION_TOP_LEVEL_SCOPE ( annotationScopeDeclarations )* ) ;
   public final void annotationTopLevelScope() throws RecognitionException {
     int annotationTopLevelScope_StartIndex = input.index();
@@ -4414,9 +4675,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 45)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:426:3: ( ^( ANNOTATION_TOP_LEVEL_SCOPE (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:426:3: ( ^(
+      // ANNOTATION_TOP_LEVEL_SCOPE (
       // annotationScopeDeclarations )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:427:3: ^( ANNOTATION_TOP_LEVEL_SCOPE (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:427:3: ^(
+      // ANNOTATION_TOP_LEVEL_SCOPE (
       // annotationScopeDeclarations )* )
       {
         match(
@@ -4428,7 +4691,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:427:32: ( annotationScopeDeclarations )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:427:32: (
+          // annotationScopeDeclarations )*
           loop68:
           do {
             int alt68 = 2;
@@ -4479,8 +4743,10 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotationTopLevelScope"
 
   // $ANTLR start "annotationScopeDeclarations"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:430:1: annotationScopeDeclarations : ( ^(
-  // ANNOTATION_METHOD_DECL modifierList type IDENT ( annotationDefaultValue )? ) | ^( VAR_DECLARATION modifierList type
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:430:1:
+  // annotationScopeDeclarations : ( ^(
+  // ANNOTATION_METHOD_DECL modifierList type IDENT ( annotationDefaultValue )? ) | ^(
+  // VAR_DECLARATION modifierList type
   // variableDeclaratorList ) | typeDeclaration );
   public final void annotationScopeDeclarations() throws RecognitionException {
     int annotationScopeDeclarations_StartIndex = input.index();
@@ -4488,8 +4754,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 46)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:431:3: ( ^( ANNOTATION_METHOD_DECL modifierList
-      // type IDENT ( annotationDefaultValue )? ) | ^( VAR_DECLARATION modifierList type variableDeclaratorList ) | typeDeclaration )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:431:3: ( ^(
+      // ANNOTATION_METHOD_DECL modifierList
+      // type IDENT ( annotationDefaultValue )? ) | ^( VAR_DECLARATION modifierList type
+      // variableDeclaratorList ) | typeDeclaration )
       int alt70 = 3;
       switch (input.LA(1)) {
         case ANNOTATION_METHOD_DECL:
@@ -4522,7 +4790,8 @@ public class JavaTreeParser extends TreeParser {
 
       switch (alt70) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:432:3: ^( ANNOTATION_METHOD_DECL
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:432:3: ^(
+          // ANNOTATION_METHOD_DECL
           // modifierList type IDENT ( annotationDefaultValue )? )
           {
             match(
@@ -4545,7 +4814,8 @@ public class JavaTreeParser extends TreeParser {
             if (state.failed) return;
             match(input, IDENT, FOLLOW_IDENT_in_annotationScopeDeclarations1465);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:432:52: ( annotationDefaultValue )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:432:52: (
+            // annotationDefaultValue )?
             int alt69 = 2;
             int LA69_0 = input.LA(1);
 
@@ -4554,7 +4824,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt69) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: annotationDefaultValue
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // annotationDefaultValue
                 {
                   pushFollow(FOLLOW_annotationDefaultValue_in_annotationScopeDeclarations1467);
                   annotationDefaultValue();
@@ -4570,7 +4841,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:434:3: ^( VAR_DECLARATION modifierList
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:434:3: ^(
+          // VAR_DECLARATION modifierList
           // type variableDeclaratorList )
           {
             match(
@@ -4600,7 +4872,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:435:5: typeDeclaration
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:435:5:
+          // typeDeclaration
           {
             pushFollow(FOLLOW_typeDeclaration_in_annotationScopeDeclarations1491);
             typeDeclaration();
@@ -4623,7 +4896,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotationScopeDeclarations"
 
   // $ANTLR start "annotationDefaultValue"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:438:1: annotationDefaultValue : ^( DEFAULT
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:438:1:
+  // annotationDefaultValue : ^( DEFAULT
   // annotationElementValue ) ;
   public final void annotationDefaultValue() throws RecognitionException {
     int annotationDefaultValue_StartIndex = input.index();
@@ -4631,8 +4905,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 47)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:439:3: ( ^( DEFAULT annotationElementValue ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:440:3: ^( DEFAULT annotationElementValue )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:439:3: ( ^( DEFAULT
+      // annotationElementValue ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:440:3: ^( DEFAULT
+      // annotationElementValue )
       {
         match(input, DEFAULT, FOLLOW_DEFAULT_in_annotationDefaultValue1507);
         if (state.failed) return;
@@ -4662,15 +4938,18 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "annotationDefaultValue"
 
   // $ANTLR start "block"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:445:1: block : ^( BLOCK_SCOPE ( blockStatement )* ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:445:1: block : ^(
+  // BLOCK_SCOPE ( blockStatement )* ) ;
   public final void block() throws RecognitionException {
     int block_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 48)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:446:3: ( ^( BLOCK_SCOPE ( blockStatement )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:447:3: ^( BLOCK_SCOPE ( blockStatement )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:446:3: ( ^( BLOCK_SCOPE
+      // ( blockStatement )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:447:3: ^( BLOCK_SCOPE (
+      // blockStatement )* )
       {
         match(input, BLOCK_SCOPE, FOLLOW_BLOCK_SCOPE_in_block1528);
         if (state.failed) return;
@@ -4678,7 +4957,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:447:17: ( blockStatement )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:447:17: (
+          // blockStatement )*
           loop71:
           do {
             int alt71 = 2;
@@ -4708,7 +4988,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt71) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: blockStatement
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // blockStatement
                 {
                   pushFollow(FOLLOW_blockStatement_in_block1530);
                   blockStatement();
@@ -4741,7 +5022,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "block"
 
   // $ANTLR start "blockStatement"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:450:1: blockStatement : ( localVariableDeclaration |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:450:1: blockStatement : (
+  // localVariableDeclaration |
   // typeDeclaration | statement );
   public final void blockStatement() throws RecognitionException {
     int blockStatement_StartIndex = input.index();
@@ -4749,7 +5031,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 49)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:451:3: ( localVariableDeclaration |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:451:3: (
+      // localVariableDeclaration |
       // typeDeclaration | statement )
       int alt72 = 3;
       switch (input.LA(1)) {
@@ -4799,7 +5082,8 @@ public class JavaTreeParser extends TreeParser {
 
       switch (alt72) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:452:3: localVariableDeclaration
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:452:3:
+          // localVariableDeclaration
           {
             pushFollow(FOLLOW_localVariableDeclaration_in_blockStatement1547);
             localVariableDeclaration();
@@ -4809,7 +5093,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:453:5: typeDeclaration
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:453:5:
+          // typeDeclaration
           {
             pushFollow(FOLLOW_typeDeclaration_in_blockStatement1553);
             typeDeclaration();
@@ -4842,7 +5127,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "blockStatement"
 
   // $ANTLR start "localVariableDeclaration"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:457:1: localVariableDeclaration : ^( VAR_DECLARATION
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:457:1:
+  // localVariableDeclaration : ^( VAR_DECLARATION
   // localModifierList type variableDeclaratorList ) ;
   public final void localVariableDeclaration() throws RecognitionException {
     int localVariableDeclaration_StartIndex = input.index();
@@ -4850,9 +5136,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 50)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:458:3: ( ^( VAR_DECLARATION localModifierList
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:458:3: ( ^(
+      // VAR_DECLARATION localModifierList
       // type variableDeclaratorList ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:459:3: ^( VAR_DECLARATION localModifierList type
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:459:3: ^(
+      // VAR_DECLARATION localModifierList type
       // variableDeclaratorList )
       {
         match(input, VAR_DECLARATION, FOLLOW_VAR_DECLARATION_in_localVariableDeclaration1575);
@@ -4893,11 +5181,16 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "localVariableDeclaration"
 
   // $ANTLR start "statement"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:462:1: statement : ( block | ^( ASSERT expression (
-  // expression )? ) | ^( IF parenthesizedExpression statement ( statement )? ) | ^( FOR forInit forCondition forUpdater statement ) |
-  // ^( FOR_EACH localModifierList type IDENT expression statement ) | ^( WHILE parenthesizedExpression statement ) | ^( DO statement
-  // parenthesizedExpression ) | ^( TRY block ( catches )? ( block )? ) | ^( SWITCH parenthesizedExpression switchBlockLabels ) | ^(
-  // SYNCHRONIZED parenthesizedExpression block ) | ^( RETURN ( expression )? ) | ^( THROW expression ) | ^( BREAK ( IDENT )? ) | ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:462:1: statement : ( block
+  // | ^( ASSERT expression (
+  // expression )? ) | ^( IF parenthesizedExpression statement ( statement )? ) | ^( FOR forInit
+  // forCondition forUpdater statement ) |
+  // ^( FOR_EACH localModifierList type IDENT expression statement ) | ^( WHILE
+  // parenthesizedExpression statement ) | ^( DO statement
+  // parenthesizedExpression ) | ^( TRY block ( catches )? ( block )? ) | ^( SWITCH
+  // parenthesizedExpression switchBlockLabels ) | ^(
+  // SYNCHRONIZED parenthesizedExpression block ) | ^( RETURN ( expression )? ) | ^( THROW
+  // expression ) | ^( BREAK ( IDENT )? ) | ^(
   // CONTINUE ( IDENT )? ) | ^( LABELED_STATEMENT IDENT statement ) | expression | SEMI );
   public final void statement() throws RecognitionException {
     int statement_StartIndex = input.index();
@@ -4905,12 +5198,18 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 51)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:463:3: ( block | ^( ASSERT expression (
-      // expression )? ) | ^( IF parenthesizedExpression statement ( statement )? ) | ^( FOR forInit forCondition forUpdater
-      // statement ) | ^( FOR_EACH localModifierList type IDENT expression statement ) | ^( WHILE parenthesizedExpression statement
-      // ) | ^( DO statement parenthesizedExpression ) | ^( TRY block ( catches )? ( block )? ) | ^( SWITCH parenthesizedExpression
-      // switchBlockLabels ) | ^( SYNCHRONIZED parenthesizedExpression block ) | ^( RETURN ( expression )? ) | ^( THROW expression
-      // ) | ^( BREAK ( IDENT )? ) | ^( CONTINUE ( IDENT )? ) | ^( LABELED_STATEMENT IDENT statement ) | expression | SEMI )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:463:3: ( block | ^(
+      // ASSERT expression (
+      // expression )? ) | ^( IF parenthesizedExpression statement ( statement )? ) | ^( FOR forInit
+      // forCondition forUpdater
+      // statement ) | ^( FOR_EACH localModifierList type IDENT expression statement ) | ^( WHILE
+      // parenthesizedExpression statement
+      // ) | ^( DO statement parenthesizedExpression ) | ^( TRY block ( catches )? ( block )? ) | ^(
+      // SWITCH parenthesizedExpression
+      // switchBlockLabels ) | ^( SYNCHRONIZED parenthesizedExpression block ) | ^( RETURN (
+      // expression )? ) | ^( THROW expression
+      // ) | ^( BREAK ( IDENT )? ) | ^( CONTINUE ( IDENT )? ) | ^( LABELED_STATEMENT IDENT statement
+      // ) | expression | SEMI )
       int alt80 = 17;
       switch (input.LA(1)) {
         case BLOCK_SCOPE:
@@ -5020,7 +5319,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:466:3: ^( ASSERT expression ( expression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:466:3: ^( ASSERT
+          // expression ( expression
           // )? )
           {
             match(input, ASSERT, FOLLOW_ASSERT_in_statement1606);
@@ -5033,7 +5333,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:466:23: ( expression )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:466:23: (
+            // expression )?
             int alt73 = 2;
             int LA73_0 = input.LA(1);
 
@@ -5042,7 +5343,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt73) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: expression
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // expression
                 {
                   pushFollow(FOLLOW_expression_in_statement1610);
                   expression();
@@ -5058,7 +5360,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:468:3: ^( IF parenthesizedExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:468:3: ^( IF
+          // parenthesizedExpression
           // statement ( statement )? )
           {
             match(input, IF, FOLLOW_IF_in_statement1621);
@@ -5076,7 +5379,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:468:42: ( statement )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:468:42: (
+            // statement )?
             int alt74 = 2;
             int LA74_0 = input.LA(1);
 
@@ -5099,7 +5403,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt74) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: statement
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // statement
                 {
                   pushFollow(FOLLOW_statement_in_statement1627);
                   statement();
@@ -5115,7 +5420,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:470:3: ^( FOR forInit forCondition
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:470:3: ^( FOR
+          // forInit forCondition
           // forUpdater statement )
           {
             match(input, FOR, FOLLOW_FOR_in_statement1638);
@@ -5149,7 +5455,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 5:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:472:3: ^( FOR_EACH localModifierList
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:472:3: ^( FOR_EACH
+          // localModifierList
           // type IDENT expression statement )
           {
             match(input, FOR_EACH, FOLLOW_FOR_EACH_in_statement1656);
@@ -5185,7 +5492,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 6:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:474:3: ^( WHILE parenthesizedExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:474:3: ^( WHILE
+          // parenthesizedExpression
           // statement )
           {
             match(input, WHILE, FOLLOW_WHILE_in_statement1676);
@@ -5209,7 +5517,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 7:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:476:3: ^( DO statement
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:476:3: ^( DO
+          // statement
           // parenthesizedExpression )
           {
             match(input, DO, FOLLOW_DO_in_statement1690);
@@ -5233,7 +5542,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 8:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:478:3: ^( TRY block ( catches )? ( block
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:478:3: ^( TRY block
+          // ( catches )? ( block
           // )? )
           {
             match(input, TRY, FOLLOW_TRY_in_statement1704);
@@ -5246,7 +5556,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:478:15: ( catches )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:478:15: ( catches
+            // )?
             int alt75 = 2;
             int LA75_0 = input.LA(1);
 
@@ -5266,7 +5577,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:478:24: ( block )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:478:24: ( block
+            // )?
             int alt76 = 2;
             int LA76_0 = input.LA(1);
 
@@ -5291,7 +5603,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 9:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:480:3: ^( SWITCH parenthesizedExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:480:3: ^( SWITCH
+          // parenthesizedExpression
           // switchBlockLabels )
           {
             match(input, SWITCH, FOLLOW_SWITCH_in_statement1723);
@@ -5315,7 +5628,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 10:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:482:3: ^( SYNCHRONIZED
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:482:3: ^(
+          // SYNCHRONIZED
           // parenthesizedExpression block )
           {
             match(input, SYNCHRONIZED, FOLLOW_SYNCHRONIZED_in_statement1737);
@@ -5339,7 +5653,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 11:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:484:3: ^( RETURN ( expression )? )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:484:3: ^( RETURN (
+          // expression )? )
           {
             match(input, RETURN, FOLLOW_RETURN_in_statement1751);
             if (state.failed) return;
@@ -5347,7 +5662,8 @@ public class JavaTreeParser extends TreeParser {
             if (input.LA(1) == Token.DOWN) {
               match(input, Token.DOWN, null);
               if (state.failed) return;
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:484:12: ( expression )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:484:12: (
+              // expression )?
               int alt77 = 2;
               int LA77_0 = input.LA(1);
 
@@ -5356,7 +5672,8 @@ public class JavaTreeParser extends TreeParser {
               }
               switch (alt77) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: expression
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                  // expression
                   {
                     pushFollow(FOLLOW_expression_in_statement1753);
                     expression();
@@ -5373,7 +5690,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 12:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:486:3: ^( THROW expression )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:486:3: ^( THROW
+          // expression )
           {
             match(input, THROW, FOLLOW_THROW_in_statement1764);
             if (state.failed) return;
@@ -5391,7 +5709,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 13:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:488:3: ^( BREAK ( IDENT )? )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:488:3: ^( BREAK (
+          // IDENT )? )
           {
             match(input, BREAK, FOLLOW_BREAK_in_statement1776);
             if (state.failed) return;
@@ -5399,7 +5718,8 @@ public class JavaTreeParser extends TreeParser {
             if (input.LA(1) == Token.DOWN) {
               match(input, Token.DOWN, null);
               if (state.failed) return;
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:488:11: ( IDENT )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:488:11: ( IDENT
+              // )?
               int alt78 = 2;
               int LA78_0 = input.LA(1);
 
@@ -5422,7 +5742,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 14:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:490:3: ^( CONTINUE ( IDENT )? )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:490:3: ^( CONTINUE
+          // ( IDENT )? )
           {
             match(input, CONTINUE, FOLLOW_CONTINUE_in_statement1789);
             if (state.failed) return;
@@ -5430,7 +5751,8 @@ public class JavaTreeParser extends TreeParser {
             if (input.LA(1) == Token.DOWN) {
               match(input, Token.DOWN, null);
               if (state.failed) return;
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:490:14: ( IDENT )?
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:490:14: ( IDENT
+              // )?
               int alt79 = 2;
               int LA79_0 = input.LA(1);
 
@@ -5453,7 +5775,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 15:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:492:3: ^( LABELED_STATEMENT IDENT
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:492:3: ^(
+          // LABELED_STATEMENT IDENT
           // statement )
           {
             match(input, LABELED_STATEMENT, FOLLOW_LABELED_STATEMENT_in_statement1802);
@@ -5504,22 +5827,26 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "statement"
 
   // $ANTLR start "catches"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:497:1: catches : ^( CATCH_CLAUSE_LIST ( catchClause )+ ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:497:1: catches : ^(
+  // CATCH_CLAUSE_LIST ( catchClause )+ ) ;
   public final void catches() throws RecognitionException {
     int catches_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 52)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:498:3: ( ^( CATCH_CLAUSE_LIST ( catchClause )+ ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:499:3: ^( CATCH_CLAUSE_LIST ( catchClause )+ )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:498:3: ( ^(
+      // CATCH_CLAUSE_LIST ( catchClause )+ ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:499:3: ^(
+      // CATCH_CLAUSE_LIST ( catchClause )+ )
       {
         match(input, CATCH_CLAUSE_LIST, FOLLOW_CATCH_CLAUSE_LIST_in_catches1836);
         if (state.failed) return;
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:499:23: ( catchClause )+
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:499:23: ( catchClause
+        // )+
         int cnt81 = 0;
         loop81:
         do {
@@ -5532,7 +5859,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt81) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: catchClause
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // catchClause
               {
                 pushFollow(FOLLOW_catchClause_in_catches1838);
                 catchClause();
@@ -5571,7 +5899,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "catches"
 
   // $ANTLR start "catchClause"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:502:1: catchClause : ^( CATCH
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:502:1: catchClause : ^(
+  // CATCH
   // formalParameterStandardDecl block ) ;
   public final void catchClause() throws RecognitionException {
     int catchClause_StartIndex = input.index();
@@ -5579,9 +5908,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 53)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:503:3: ( ^( CATCH formalParameterStandardDecl
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:503:3: ( ^( CATCH
+      // formalParameterStandardDecl
       // block ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:504:3: ^( CATCH formalParameterStandardDecl block )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:504:3: ^( CATCH
+      // formalParameterStandardDecl block )
       {
         match(input, CATCH, FOLLOW_CATCH_in_catchClause1856);
         if (state.failed) return;
@@ -5616,7 +5947,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "catchClause"
 
   // $ANTLR start "switchBlockLabels"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:507:1: switchBlockLabels : ^( SWITCH_BLOCK_LABEL_LIST (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:507:1: switchBlockLabels :
+  // ^( SWITCH_BLOCK_LABEL_LIST (
   // switchCaseLabel )* ( switchDefaultLabel )? ( switchCaseLabel )* ) ;
   public final void switchBlockLabels() throws RecognitionException {
     int switchBlockLabels_StartIndex = input.index();
@@ -5624,9 +5956,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 54)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:508:3: ( ^( SWITCH_BLOCK_LABEL_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:508:3: ( ^(
+      // SWITCH_BLOCK_LABEL_LIST (
       // switchCaseLabel )* ( switchDefaultLabel )? ( switchCaseLabel )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:3: ^( SWITCH_BLOCK_LABEL_LIST (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:3: ^(
+      // SWITCH_BLOCK_LABEL_LIST (
       // switchCaseLabel )* ( switchDefaultLabel )? ( switchCaseLabel )* )
       {
         match(
@@ -5638,7 +5972,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:29: ( switchCaseLabel )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:29: (
+          // switchCaseLabel )*
           loop82:
           do {
             int alt82 = 2;
@@ -5654,7 +5989,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt82) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: switchCaseLabel
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // switchCaseLabel
                 {
                   pushFollow(FOLLOW_switchCaseLabel_in_switchBlockLabels1879);
                   switchCaseLabel();
@@ -5669,7 +6005,8 @@ public class JavaTreeParser extends TreeParser {
             }
           } while (true);
 
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:46: ( switchDefaultLabel )?
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:46: (
+          // switchDefaultLabel )?
           int alt83 = 2;
           int LA83_0 = input.LA(1);
 
@@ -5678,7 +6015,8 @@ public class JavaTreeParser extends TreeParser {
           }
           switch (alt83) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: switchDefaultLabel
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // switchDefaultLabel
               {
                 pushFollow(FOLLOW_switchDefaultLabel_in_switchBlockLabels1882);
                 switchDefaultLabel();
@@ -5689,7 +6027,8 @@ public class JavaTreeParser extends TreeParser {
               break;
           }
 
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:66: ( switchCaseLabel )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:66: (
+          // switchCaseLabel )*
           loop84:
           do {
             int alt84 = 2;
@@ -5701,7 +6040,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt84) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: switchCaseLabel
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // switchCaseLabel
                 {
                   pushFollow(FOLLOW_switchCaseLabel_in_switchBlockLabels1885);
                   switchCaseLabel();
@@ -5734,7 +6074,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "switchBlockLabels"
 
   // $ANTLR start "switchCaseLabel"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:512:1: switchCaseLabel : ^( CASE expression (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:512:1: switchCaseLabel : ^(
+  // CASE expression (
   // blockStatement )* ) ;
   public final void switchCaseLabel() throws RecognitionException {
     int switchCaseLabel_StartIndex = input.index();
@@ -5742,8 +6083,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 55)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:513:3: ( ^( CASE expression ( blockStatement )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:514:3: ^( CASE expression ( blockStatement )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:513:3: ( ^( CASE
+      // expression ( blockStatement )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:514:3: ^( CASE
+      // expression ( blockStatement )* )
       {
         match(input, CASE, FOLLOW_CASE_in_switchCaseLabel1903);
         if (state.failed) return;
@@ -5755,7 +6098,8 @@ public class JavaTreeParser extends TreeParser {
 
         state._fsp--;
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:514:21: ( blockStatement )*
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:514:21: (
+        // blockStatement )*
         loop85:
         do {
           int alt85 = 2;
@@ -5785,7 +6129,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt85) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: blockStatement
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+              // blockStatement
               {
                 pushFollow(FOLLOW_blockStatement_in_switchCaseLabel1907);
                 blockStatement();
@@ -5817,7 +6162,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "switchCaseLabel"
 
   // $ANTLR start "switchDefaultLabel"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:517:1: switchDefaultLabel : ^( DEFAULT ( blockStatement
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:517:1: switchDefaultLabel :
+  // ^( DEFAULT ( blockStatement
   // )* ) ;
   public final void switchDefaultLabel() throws RecognitionException {
     int switchDefaultLabel_StartIndex = input.index();
@@ -5825,8 +6171,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 56)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:518:3: ( ^( DEFAULT ( blockStatement )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:519:3: ^( DEFAULT ( blockStatement )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:518:3: ( ^( DEFAULT (
+      // blockStatement )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:519:3: ^( DEFAULT (
+      // blockStatement )* )
       {
         match(input, DEFAULT, FOLLOW_DEFAULT_in_switchDefaultLabel1925);
         if (state.failed) return;
@@ -5834,7 +6182,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:519:13: ( blockStatement )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:519:13: (
+          // blockStatement )*
           loop86:
           do {
             int alt86 = 2;
@@ -5864,7 +6213,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt86) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: blockStatement
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // blockStatement
                 {
                   pushFollow(FOLLOW_blockStatement_in_switchDefaultLabel1927);
                   blockStatement();
@@ -5897,7 +6247,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "switchDefaultLabel"
 
   // $ANTLR start "forInit"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:522:1: forInit : ^( FOR_INIT ( localVariableDeclaration
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:522:1: forInit : ^(
+  // FOR_INIT ( localVariableDeclaration
   // | ( expression )* )? ) ;
   public final void forInit() throws RecognitionException {
     int forInit_StartIndex = input.index();
@@ -5905,9 +6256,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 57)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:523:3: ( ^( FOR_INIT ( localVariableDeclaration
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:523:3: ( ^( FOR_INIT (
+      // localVariableDeclaration
       // | ( expression )* )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:524:3: ^( FOR_INIT ( localVariableDeclaration |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:524:3: ^( FOR_INIT (
+      // localVariableDeclaration |
       // ( expression )* )? )
       {
         match(input, FOR_INIT, FOLLOW_FOR_INIT_in_forInit1950);
@@ -5916,7 +6269,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:526:5: ( localVariableDeclaration | (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:526:5: (
+          // localVariableDeclaration | (
           // expression )* )?
           int alt88 = 3;
           switch (input.LA(1)) {
@@ -5943,7 +6297,8 @@ public class JavaTreeParser extends TreeParser {
 
           switch (alt88) {
             case 1:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:527:7: localVariableDeclaration
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:527:7:
+              // localVariableDeclaration
               {
                 pushFollow(FOLLOW_localVariableDeclaration_in_forInit1964);
                 localVariableDeclaration();
@@ -5953,9 +6308,11 @@ public class JavaTreeParser extends TreeParser {
               }
               break;
             case 2:
-              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:528:9: ( expression )*
+              // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:528:9: (
+              // expression )*
               {
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:528:9: ( expression )*
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:528:9: (
+                // expression )*
                 loop87:
                 do {
                   int alt87 = 2;
@@ -5967,7 +6324,8 @@ public class JavaTreeParser extends TreeParser {
 
                   switch (alt87) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: expression
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                      // expression
                       {
                         pushFollow(FOLLOW_expression_in_forInit1974);
                         expression();
@@ -6003,15 +6361,18 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "forInit"
 
   // $ANTLR start "forCondition"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:533:1: forCondition : ^( FOR_CONDITION ( expression )? ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:533:1: forCondition : ^(
+  // FOR_CONDITION ( expression )? ) ;
   public final void forCondition() throws RecognitionException {
     int forCondition_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 58)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:534:3: ( ^( FOR_CONDITION ( expression )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:535:3: ^( FOR_CONDITION ( expression )? )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:534:3: ( ^(
+      // FOR_CONDITION ( expression )? ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:535:3: ^( FOR_CONDITION
+      // ( expression )? )
       {
         match(input, FOR_CONDITION, FOLLOW_FOR_CONDITION_in_forCondition2003);
         if (state.failed) return;
@@ -6019,7 +6380,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:535:19: ( expression )?
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:535:19: (
+          // expression )?
           int alt89 = 2;
           int LA89_0 = input.LA(1);
 
@@ -6057,15 +6419,18 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "forCondition"
 
   // $ANTLR start "forUpdater"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:538:1: forUpdater : ^( FOR_UPDATE ( expression )* ) ;
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:538:1: forUpdater : ^(
+  // FOR_UPDATE ( expression )* ) ;
   public final void forUpdater() throws RecognitionException {
     int forUpdater_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 59)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:539:3: ( ^( FOR_UPDATE ( expression )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:540:3: ^( FOR_UPDATE ( expression )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:539:3: ( ^( FOR_UPDATE
+      // ( expression )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:540:3: ^( FOR_UPDATE (
+      // expression )* )
       {
         match(input, FOR_UPDATE, FOLLOW_FOR_UPDATE_in_forUpdater2023);
         if (state.failed) return;
@@ -6073,7 +6438,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:540:16: ( expression )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:540:16: (
+          // expression )*
           loop90:
           do {
             int alt90 = 2;
@@ -6085,7 +6451,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt90) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: expression
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // expression
                 {
                   pushFollow(FOLLOW_expression_in_forUpdater2025);
                   expression();
@@ -6118,7 +6485,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "forUpdater"
 
   // $ANTLR start "evaluate"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:545:1: evaluate returns [com.sun.jdi.Value value] :
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:545:1: evaluate returns
+  // [com.sun.jdi.Value value] :
   // expression ;
   public final com.sun.jdi.Value evaluate() throws RecognitionException {
     com.sun.jdi.Value value = null;
@@ -6156,7 +6524,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "evaluate"
 
   // $ANTLR start "parenthesizedExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:553:1: parenthesizedExpression returns [ExpressionValue
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:553:1:
+  // parenthesizedExpression returns [ExpressionValue
   // value] : ^( PARENTESIZED_EXPR expression ) ;
   public final ExpressionValue parenthesizedExpression() throws RecognitionException {
     ExpressionValue value = null;
@@ -6167,8 +6536,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 61)) {
         return value;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:554:3: ( ^( PARENTESIZED_EXPR expression ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:555:3: ^( PARENTESIZED_EXPR expression )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:554:3: ( ^(
+      // PARENTESIZED_EXPR expression ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:555:3: ^(
+      // PARENTESIZED_EXPR expression )
       {
         match(input, PARENTESIZED_EXPR, FOLLOW_PARENTESIZED_EXPR_in_parenthesizedExpression2084);
         if (state.failed) return value;
@@ -6202,7 +6573,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "parenthesizedExpression"
 
   // $ANTLR start "expression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:561:1: expression returns [ExpressionValue value] : ^(
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:561:1: expression returns
+  // [ExpressionValue value] : ^(
   // EXPR expr ) ;
   public final ExpressionValue expression() throws RecognitionException {
     ExpressionValue value = null;
@@ -6213,7 +6585,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 62)) {
         return value;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:562:3: ( ^( EXPR expr ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:562:3: ( ^( EXPR expr )
+      // )
       // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:563:3: ^( EXPR expr )
       {
         match(input, EXPR, FOLLOW_EXPR_in_expression2126);
@@ -6248,17 +6621,28 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "expression"
 
   // $ANTLR start "expr"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:569:1: expr returns [ExpressionValue value] : ( ^(
-  // ASSIGN a= expr b= expr ) | ^( PLUS_ASSIGN a= expr b= expr ) | ^( MINUS_ASSIGN a= expr b= expr ) | ^( STAR_ASSIGN a= expr b= expr )
-  // | ^( DIV_ASSIGN a= expr b= expr ) | ^( AND_ASSIGN a= expr b= expr ) | ^( OR_ASSIGN a= expr b= expr ) | ^( XOR_ASSIGN a= expr b=
-  // expr ) | ^( MOD_ASSIGN a= expr b= expr ) | ^( BIT_SHIFT_RIGHT_ASSIGN a= expr b= expr ) | ^( SHIFT_RIGHT_ASSIGN a= expr b= expr ) |
-  // ^( SHIFT_LEFT_ASSIGN a= expr b= expr ) | ^( QUESTION test= expr a= expr b= expr ) | ^( LOGICAL_OR a= expr b= expr ) | ^(
-  // LOGICAL_AND a= expr b= expr ) | ^( OR a= expr b= expr ) | ^( XOR a= expr b= expr ) | ^( AND a= expr b= expr ) | ^( EQUAL a= expr
-  // b= expr ) | ^( NOT_EQUAL a= expr b= expr ) | ^( INSTANCEOF expr type ) | ^( LESS_OR_EQUAL a= expr b= expr ) | ^( GREATER_OR_EQUAL
-  // a= expr b= expr ) | ^( BIT_SHIFT_RIGHT a= expr b= expr ) | ^( SHIFT_RIGHT a= expr b= expr ) | ^( GREATER_THAN a= expr b= expr ) |
-  // ^( SHIFT_LEFT a= expr b= expr ) | ^( LESS_THAN a= expr b= expr ) | ^( PLUS a= expr b= expr ) | ^( MINUS a= expr b= expr ) | ^(
-  // STAR a= expr b= expr ) | ^( DIV a= expr b= expr ) | ^( MOD a= expr b= expr ) | ^( UNARY_PLUS a= expr ) | ^( UNARY_MINUS a= expr )
-  // | ^( PRE_INC a= expr ) | ^( PRE_DEC expr ) | ^( POST_INC a= expr ) | ^( POST_DEC expr ) | ^( NOT a= expr ) | ^( LOGICAL_NOT a=
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:569:1: expr returns
+  // [ExpressionValue value] : ( ^(
+  // ASSIGN a= expr b= expr ) | ^( PLUS_ASSIGN a= expr b= expr ) | ^( MINUS_ASSIGN a= expr b= expr )
+  // | ^( STAR_ASSIGN a= expr b= expr )
+  // | ^( DIV_ASSIGN a= expr b= expr ) | ^( AND_ASSIGN a= expr b= expr ) | ^( OR_ASSIGN a= expr b=
+  // expr ) | ^( XOR_ASSIGN a= expr b=
+  // expr ) | ^( MOD_ASSIGN a= expr b= expr ) | ^( BIT_SHIFT_RIGHT_ASSIGN a= expr b= expr ) | ^(
+  // SHIFT_RIGHT_ASSIGN a= expr b= expr ) |
+  // ^( SHIFT_LEFT_ASSIGN a= expr b= expr ) | ^( QUESTION test= expr a= expr b= expr ) | ^(
+  // LOGICAL_OR a= expr b= expr ) | ^(
+  // LOGICAL_AND a= expr b= expr ) | ^( OR a= expr b= expr ) | ^( XOR a= expr b= expr ) | ^( AND a=
+  // expr b= expr ) | ^( EQUAL a= expr
+  // b= expr ) | ^( NOT_EQUAL a= expr b= expr ) | ^( INSTANCEOF expr type ) | ^( LESS_OR_EQUAL a=
+  // expr b= expr ) | ^( GREATER_OR_EQUAL
+  // a= expr b= expr ) | ^( BIT_SHIFT_RIGHT a= expr b= expr ) | ^( SHIFT_RIGHT a= expr b= expr ) |
+  // ^( GREATER_THAN a= expr b= expr ) |
+  // ^( SHIFT_LEFT a= expr b= expr ) | ^( LESS_THAN a= expr b= expr ) | ^( PLUS a= expr b= expr ) |
+  // ^( MINUS a= expr b= expr ) | ^(
+  // STAR a= expr b= expr ) | ^( DIV a= expr b= expr ) | ^( MOD a= expr b= expr ) | ^( UNARY_PLUS a=
+  // expr ) | ^( UNARY_MINUS a= expr )
+  // | ^( PRE_INC a= expr ) | ^( PRE_DEC expr ) | ^( POST_INC a= expr ) | ^( POST_DEC expr ) | ^(
+  // NOT a= expr ) | ^( LOGICAL_NOT a=
   // expr ) | ^( CAST_EXPR type expr ) | primaryExpression );
   public final ExpressionValue expr() throws RecognitionException {
     ExpressionValue value = null;
@@ -6312,18 +6696,30 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 63)) {
         return value;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:573:3: ( ^( ASSIGN a= expr b= expr ) | ^(
-      // PLUS_ASSIGN a= expr b= expr ) | ^( MINUS_ASSIGN a= expr b= expr ) | ^( STAR_ASSIGN a= expr b= expr ) | ^( DIV_ASSIGN a=
-      // expr b= expr ) | ^( AND_ASSIGN a= expr b= expr ) | ^( OR_ASSIGN a= expr b= expr ) | ^( XOR_ASSIGN a= expr b= expr ) | ^(
-      // MOD_ASSIGN a= expr b= expr ) | ^( BIT_SHIFT_RIGHT_ASSIGN a= expr b= expr ) | ^( SHIFT_RIGHT_ASSIGN a= expr b= expr ) | ^(
-      // SHIFT_LEFT_ASSIGN a= expr b= expr ) | ^( QUESTION test= expr a= expr b= expr ) | ^( LOGICAL_OR a= expr b= expr ) | ^(
-      // LOGICAL_AND a= expr b= expr ) | ^( OR a= expr b= expr ) | ^( XOR a= expr b= expr ) | ^( AND a= expr b= expr ) | ^( EQUAL
-      // a= expr b= expr ) | ^( NOT_EQUAL a= expr b= expr ) | ^( INSTANCEOF expr type ) | ^( LESS_OR_EQUAL a= expr b= expr ) | ^(
-      // GREATER_OR_EQUAL a= expr b= expr ) | ^( BIT_SHIFT_RIGHT a= expr b= expr ) | ^( SHIFT_RIGHT a= expr b= expr ) | ^(
-      // GREATER_THAN a= expr b= expr ) | ^( SHIFT_LEFT a= expr b= expr ) | ^( LESS_THAN a= expr b= expr ) | ^( PLUS a= expr b=
-      // expr ) | ^( MINUS a= expr b= expr ) | ^( STAR a= expr b= expr ) | ^( DIV a= expr b= expr ) | ^( MOD a= expr b= expr ) | ^(
-      // UNARY_PLUS a= expr ) | ^( UNARY_MINUS a= expr ) | ^( PRE_INC a= expr ) | ^( PRE_DEC expr ) | ^( POST_INC a= expr ) | ^(
-      // POST_DEC expr ) | ^( NOT a= expr ) | ^( LOGICAL_NOT a= expr ) | ^( CAST_EXPR type expr ) | primaryExpression )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:573:3: ( ^( ASSIGN a=
+      // expr b= expr ) | ^(
+      // PLUS_ASSIGN a= expr b= expr ) | ^( MINUS_ASSIGN a= expr b= expr ) | ^( STAR_ASSIGN a= expr
+      // b= expr ) | ^( DIV_ASSIGN a=
+      // expr b= expr ) | ^( AND_ASSIGN a= expr b= expr ) | ^( OR_ASSIGN a= expr b= expr ) | ^(
+      // XOR_ASSIGN a= expr b= expr ) | ^(
+      // MOD_ASSIGN a= expr b= expr ) | ^( BIT_SHIFT_RIGHT_ASSIGN a= expr b= expr ) | ^(
+      // SHIFT_RIGHT_ASSIGN a= expr b= expr ) | ^(
+      // SHIFT_LEFT_ASSIGN a= expr b= expr ) | ^( QUESTION test= expr a= expr b= expr ) | ^(
+      // LOGICAL_OR a= expr b= expr ) | ^(
+      // LOGICAL_AND a= expr b= expr ) | ^( OR a= expr b= expr ) | ^( XOR a= expr b= expr ) | ^( AND
+      // a= expr b= expr ) | ^( EQUAL
+      // a= expr b= expr ) | ^( NOT_EQUAL a= expr b= expr ) | ^( INSTANCEOF expr type ) | ^(
+      // LESS_OR_EQUAL a= expr b= expr ) | ^(
+      // GREATER_OR_EQUAL a= expr b= expr ) | ^( BIT_SHIFT_RIGHT a= expr b= expr ) | ^( SHIFT_RIGHT
+      // a= expr b= expr ) | ^(
+      // GREATER_THAN a= expr b= expr ) | ^( SHIFT_LEFT a= expr b= expr ) | ^( LESS_THAN a= expr b=
+      // expr ) | ^( PLUS a= expr b=
+      // expr ) | ^( MINUS a= expr b= expr ) | ^( STAR a= expr b= expr ) | ^( DIV a= expr b= expr )
+      // | ^( MOD a= expr b= expr ) | ^(
+      // UNARY_PLUS a= expr ) | ^( UNARY_MINUS a= expr ) | ^( PRE_INC a= expr ) | ^( PRE_DEC expr )
+      // | ^( POST_INC a= expr ) | ^(
+      // POST_DEC expr ) | ^( NOT a= expr ) | ^( LOGICAL_NOT a= expr ) | ^( CAST_EXPR type expr ) |
+      // primaryExpression )
       int alt91 = 43;
       switch (input.LA(1)) {
         case ASSIGN:
@@ -6573,7 +6969,8 @@ public class JavaTreeParser extends TreeParser {
 
       switch (alt91) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:574:3: ^( ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:574:3: ^( ASSIGN a=
+          // expr b= expr )
           {
             ASSIGN4 = (CommonTree) match(input, ASSIGN, FOLLOW_ASSIGN_in_expr2207);
             if (state.failed) return value;
@@ -6600,7 +6997,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:579:3: ^( PLUS_ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:579:3: ^(
+          // PLUS_ASSIGN a= expr b= expr )
           {
             PLUS_ASSIGN5 = (CommonTree) match(input, PLUS_ASSIGN, FOLLOW_PLUS_ASSIGN_in_expr2271);
             if (state.failed) return value;
@@ -6627,7 +7025,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:584:3: ^( MINUS_ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:584:3: ^(
+          // MINUS_ASSIGN a= expr b= expr )
           {
             MINUS_ASSIGN6 =
                 (CommonTree) match(input, MINUS_ASSIGN, FOLLOW_MINUS_ASSIGN_in_expr2307);
@@ -6655,7 +7054,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:589:3: ^( STAR_ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:589:3: ^(
+          // STAR_ASSIGN a= expr b= expr )
           {
             STAR_ASSIGN7 = (CommonTree) match(input, STAR_ASSIGN, FOLLOW_STAR_ASSIGN_in_expr2343);
             if (state.failed) return value;
@@ -6682,7 +7082,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 5:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:594:3: ^( DIV_ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:594:3: ^(
+          // DIV_ASSIGN a= expr b= expr )
           {
             DIV_ASSIGN8 = (CommonTree) match(input, DIV_ASSIGN, FOLLOW_DIV_ASSIGN_in_expr2379);
             if (state.failed) return value;
@@ -6709,7 +7110,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 6:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:599:3: ^( AND_ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:599:3: ^(
+          // AND_ASSIGN a= expr b= expr )
           {
             AND_ASSIGN9 = (CommonTree) match(input, AND_ASSIGN, FOLLOW_AND_ASSIGN_in_expr2415);
             if (state.failed) return value;
@@ -6736,7 +7138,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 7:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:604:3: ^( OR_ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:604:3: ^( OR_ASSIGN
+          // a= expr b= expr )
           {
             OR_ASSIGN10 = (CommonTree) match(input, OR_ASSIGN, FOLLOW_OR_ASSIGN_in_expr2479);
             if (state.failed) return value;
@@ -6763,7 +7166,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 8:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:609:3: ^( XOR_ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:609:3: ^(
+          // XOR_ASSIGN a= expr b= expr )
           {
             XOR_ASSIGN11 = (CommonTree) match(input, XOR_ASSIGN, FOLLOW_XOR_ASSIGN_in_expr2543);
             if (state.failed) return value;
@@ -6790,7 +7194,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 9:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:614:3: ^( MOD_ASSIGN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:614:3: ^(
+          // MOD_ASSIGN a= expr b= expr )
           {
             MOD_ASSIGN12 = (CommonTree) match(input, MOD_ASSIGN, FOLLOW_MOD_ASSIGN_in_expr2607);
             if (state.failed) return value;
@@ -6817,7 +7222,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 10:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:619:3: ^( BIT_SHIFT_RIGHT_ASSIGN a= expr
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:619:3: ^(
+          // BIT_SHIFT_RIGHT_ASSIGN a= expr
           // b= expr )
           {
             BIT_SHIFT_RIGHT_ASSIGN13 =
@@ -6851,7 +7257,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 11:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:624:3: ^( SHIFT_RIGHT_ASSIGN a= expr b=
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:624:3: ^(
+          // SHIFT_RIGHT_ASSIGN a= expr b=
           // expr )
           {
             SHIFT_RIGHT_ASSIGN14 =
@@ -6883,7 +7290,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 12:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:629:3: ^( SHIFT_LEFT_ASSIGN a= expr b=
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:629:3: ^(
+          // SHIFT_LEFT_ASSIGN a= expr b=
           // expr )
           {
             SHIFT_LEFT_ASSIGN15 =
@@ -6914,7 +7322,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 13:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:634:3: ^( QUESTION test= expr a= expr b=
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:634:3: ^( QUESTION
+          // test= expr a= expr b=
           // expr )
           {
             match(input, QUESTION, FOLLOW_QUESTION_in_expr2863);
@@ -6947,7 +7356,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 14:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:639:3: ^( LOGICAL_OR a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:639:3: ^(
+          // LOGICAL_OR a= expr b= expr )
           {
             LOGICAL_OR16 = (CommonTree) match(input, LOGICAL_OR, FOLLOW_LOGICAL_OR_in_expr2931);
             if (state.failed) return value;
@@ -6974,7 +7384,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 15:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:644:3: ^( LOGICAL_AND a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:644:3: ^(
+          // LOGICAL_AND a= expr b= expr )
           {
             LOGICAL_AND17 = (CommonTree) match(input, LOGICAL_AND, FOLLOW_LOGICAL_AND_in_expr2995);
             if (state.failed) return value;
@@ -7001,7 +7412,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 16:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:649:3: ^( OR a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:649:3: ^( OR a=
+          // expr b= expr )
           {
             OR18 = (CommonTree) match(input, OR, FOLLOW_OR_in_expr3059);
             if (state.failed) return value;
@@ -7028,7 +7440,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 17:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:654:3: ^( XOR a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:654:3: ^( XOR a=
+          // expr b= expr )
           {
             XOR19 = (CommonTree) match(input, XOR, FOLLOW_XOR_in_expr3123);
             if (state.failed) return value;
@@ -7055,7 +7468,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 18:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:659:3: ^( AND a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:659:3: ^( AND a=
+          // expr b= expr )
           {
             AND20 = (CommonTree) match(input, AND, FOLLOW_AND_in_expr3187);
             if (state.failed) return value;
@@ -7082,7 +7496,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 19:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:664:3: ^( EQUAL a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:664:3: ^( EQUAL a=
+          // expr b= expr )
           {
             EQUAL21 = (CommonTree) match(input, EQUAL, FOLLOW_EQUAL_in_expr3251);
             if (state.failed) return value;
@@ -7109,7 +7524,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 20:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:669:3: ^( NOT_EQUAL a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:669:3: ^( NOT_EQUAL
+          // a= expr b= expr )
           {
             NOT_EQUAL22 = (CommonTree) match(input, NOT_EQUAL, FOLLOW_NOT_EQUAL_in_expr3315);
             if (state.failed) return value;
@@ -7136,7 +7552,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 21:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:674:3: ^( INSTANCEOF expr type )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:674:3: ^(
+          // INSTANCEOF expr type )
           {
             match(input, INSTANCEOF, FOLLOW_INSTANCEOF_in_expr3379);
             if (state.failed) return value;
@@ -7163,7 +7580,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 22:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:679:3: ^( LESS_OR_EQUAL a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:679:3: ^(
+          // LESS_OR_EQUAL a= expr b= expr )
           {
             LESS_OR_EQUAL23 =
                 (CommonTree) match(input, LESS_OR_EQUAL, FOLLOW_LESS_OR_EQUAL_in_expr3439);
@@ -7191,7 +7609,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 23:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:684:3: ^( GREATER_OR_EQUAL a= expr b=
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:684:3: ^(
+          // GREATER_OR_EQUAL a= expr b=
           // expr )
           {
             GREATER_OR_EQUAL24 =
@@ -7222,7 +7641,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 24:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:689:3: ^( BIT_SHIFT_RIGHT a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:689:3: ^(
+          // BIT_SHIFT_RIGHT a= expr b= expr )
           {
             BIT_SHIFT_RIGHT25 =
                 (CommonTree) match(input, BIT_SHIFT_RIGHT, FOLLOW_BIT_SHIFT_RIGHT_in_expr3567);
@@ -7251,7 +7671,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 25:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:694:3: ^( SHIFT_RIGHT a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:694:3: ^(
+          // SHIFT_RIGHT a= expr b= expr )
           {
             SHIFT_RIGHT26 = (CommonTree) match(input, SHIFT_RIGHT, FOLLOW_SHIFT_RIGHT_in_expr3603);
             if (state.failed) return value;
@@ -7278,7 +7699,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 26:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:699:3: ^( GREATER_THAN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:699:3: ^(
+          // GREATER_THAN a= expr b= expr )
           {
             GREATER_THAN27 =
                 (CommonTree) match(input, GREATER_THAN, FOLLOW_GREATER_THAN_in_expr3639);
@@ -7306,7 +7728,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 27:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:704:3: ^( SHIFT_LEFT a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:704:3: ^(
+          // SHIFT_LEFT a= expr b= expr )
           {
             SHIFT_LEFT28 = (CommonTree) match(input, SHIFT_LEFT, FOLLOW_SHIFT_LEFT_in_expr3675);
             if (state.failed) return value;
@@ -7333,7 +7756,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 28:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:709:3: ^( LESS_THAN a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:709:3: ^( LESS_THAN
+          // a= expr b= expr )
           {
             LESS_THAN29 = (CommonTree) match(input, LESS_THAN, FOLLOW_LESS_THAN_in_expr3711);
             if (state.failed) return value;
@@ -7360,7 +7784,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 29:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:714:3: ^( PLUS a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:714:3: ^( PLUS a=
+          // expr b= expr )
           {
             PLUS30 = (CommonTree) match(input, PLUS, FOLLOW_PLUS_in_expr3747);
             if (state.failed) return value;
@@ -7387,7 +7812,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 30:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:719:3: ^( MINUS a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:719:3: ^( MINUS a=
+          // expr b= expr )
           {
             MINUS31 = (CommonTree) match(input, MINUS, FOLLOW_MINUS_in_expr3783);
             if (state.failed) return value;
@@ -7414,7 +7840,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 31:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:724:3: ^( STAR a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:724:3: ^( STAR a=
+          // expr b= expr )
           {
             STAR32 = (CommonTree) match(input, STAR, FOLLOW_STAR_in_expr3819);
             if (state.failed) return value;
@@ -7441,7 +7868,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 32:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:729:3: ^( DIV a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:729:3: ^( DIV a=
+          // expr b= expr )
           {
             DIV33 = (CommonTree) match(input, DIV, FOLLOW_DIV_in_expr3855);
             if (state.failed) return value;
@@ -7468,7 +7896,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 33:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:734:3: ^( MOD a= expr b= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:734:3: ^( MOD a=
+          // expr b= expr )
           {
             MOD34 = (CommonTree) match(input, MOD, FOLLOW_MOD_in_expr3891);
             if (state.failed) return value;
@@ -7495,7 +7924,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 34:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:739:3: ^( UNARY_PLUS a= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:739:3: ^(
+          // UNARY_PLUS a= expr )
           {
             UNARY_PLUS35 = (CommonTree) match(input, UNARY_PLUS, FOLLOW_UNARY_PLUS_in_expr3927);
             if (state.failed) return value;
@@ -7517,7 +7947,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 35:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:744:3: ^( UNARY_MINUS a= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:744:3: ^(
+          // UNARY_MINUS a= expr )
           {
             UNARY_MINUS36 = (CommonTree) match(input, UNARY_MINUS, FOLLOW_UNARY_MINUS_in_expr3959);
             if (state.failed) return value;
@@ -7539,7 +7970,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 36:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:749:3: ^( PRE_INC a= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:749:3: ^( PRE_INC
+          // a= expr )
           {
             match(input, PRE_INC, FOLLOW_PRE_INC_in_expr3991);
             if (state.failed) return value;
@@ -7561,7 +7993,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 37:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:754:3: ^( PRE_DEC expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:754:3: ^( PRE_DEC
+          // expr )
           {
             match(input, PRE_DEC, FOLLOW_PRE_DEC_in_expr4023);
             if (state.failed) return value;
@@ -7583,7 +8016,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 38:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:759:3: ^( POST_INC a= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:759:3: ^( POST_INC
+          // a= expr )
           {
             match(input, POST_INC, FOLLOW_POST_INC_in_expr4053);
             if (state.failed) return value;
@@ -7605,7 +8039,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 39:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:764:3: ^( POST_DEC expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:764:3: ^( POST_DEC
+          // expr )
           {
             match(input, POST_DEC, FOLLOW_POST_DEC_in_expr4085);
             if (state.failed) return value;
@@ -7627,7 +8062,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 40:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:769:3: ^( NOT a= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:769:3: ^( NOT a=
+          // expr )
           {
             NOT37 = (CommonTree) match(input, NOT, FOLLOW_NOT_in_expr4115);
             if (state.failed) return value;
@@ -7649,7 +8085,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 41:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:774:3: ^( LOGICAL_NOT a= expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:774:3: ^(
+          // LOGICAL_NOT a= expr )
           {
             LOGICAL_NOT38 = (CommonTree) match(input, LOGICAL_NOT, FOLLOW_LOGICAL_NOT_in_expr4147);
             if (state.failed) return value;
@@ -7671,7 +8108,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 42:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:779:3: ^( CAST_EXPR type expr )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:779:3: ^( CAST_EXPR
+          // type expr )
           {
             match(input, CAST_EXPR, FOLLOW_CAST_EXPR_in_expr4179);
             if (state.failed) return value;
@@ -7698,7 +8136,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 43:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:783:5: primaryExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:783:5:
+          // primaryExpression
           {
             pushFollow(FOLLOW_primaryExpression_in_expr4208);
             primaryExpression39 = primaryExpression();
@@ -7729,10 +8168,14 @@ public class JavaTreeParser extends TreeParser {
   };
 
   // $ANTLR start "primaryExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:789:1: primaryExpression returns [ExpressionValue value]
-  // : ( ^( DOT (e= primaryExpression ( IDENT | THIS | SUPER | innerNewExpression | CLASS ) | primitiveType CLASS | VOID CLASS ) ) |
-  // parenthesizedExpression | IDENT | ^( METHOD_CALL o= primaryExpression ( genericTypeArgumentList )? arguments ) |
-  // explicitConstructorCall | ^( ARRAY_ELEMENT_ACCESS arr= primaryExpression index= expression ) | literal | newExpression | THIS |
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:789:1: primaryExpression
+  // returns [ExpressionValue value]
+  // : ( ^( DOT (e= primaryExpression ( IDENT | THIS | SUPER | innerNewExpression | CLASS ) |
+  // primitiveType CLASS | VOID CLASS ) ) |
+  // parenthesizedExpression | IDENT | ^( METHOD_CALL o= primaryExpression ( genericTypeArgumentList
+  // )? arguments ) |
+  // explicitConstructorCall | ^( ARRAY_ELEMENT_ACCESS arr= primaryExpression index= expression ) |
+  // literal | newExpression | THIS |
   // arrayTypeDeclarator | SUPER );
   public final JavaTreeParser.primaryExpression_return primaryExpression()
       throws RecognitionException {
@@ -7759,10 +8202,14 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 64)) {
         return retval;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:793:3: ( ^( DOT (e= primaryExpression ( IDENT |
-      // THIS | SUPER | innerNewExpression | CLASS ) | primitiveType CLASS | VOID CLASS ) ) | parenthesizedExpression | IDENT | ^(
-      // METHOD_CALL o= primaryExpression ( genericTypeArgumentList )? arguments ) | explicitConstructorCall | ^(
-      // ARRAY_ELEMENT_ACCESS arr= primaryExpression index= expression ) | literal | newExpression | THIS | arrayTypeDeclarator |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:793:3: ( ^( DOT (e=
+      // primaryExpression ( IDENT |
+      // THIS | SUPER | innerNewExpression | CLASS ) | primitiveType CLASS | VOID CLASS ) ) |
+      // parenthesizedExpression | IDENT | ^(
+      // METHOD_CALL o= primaryExpression ( genericTypeArgumentList )? arguments ) |
+      // explicitConstructorCall | ^(
+      // ARRAY_ELEMENT_ACCESS arr= primaryExpression index= expression ) | literal | newExpression |
+      // THIS | arrayTypeDeclarator |
       // SUPER )
       int alt95 = 11;
       switch (input.LA(1)) {
@@ -7843,15 +8290,18 @@ public class JavaTreeParser extends TreeParser {
 
       switch (alt95) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:794:3: ^( DOT (e= primaryExpression (
-          // IDENT | THIS | SUPER | innerNewExpression | CLASS ) | primitiveType CLASS | VOID CLASS ) )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:794:3: ^( DOT (e=
+          // primaryExpression (
+          // IDENT | THIS | SUPER | innerNewExpression | CLASS ) | primitiveType CLASS | VOID CLASS
+          // ) )
           {
             match(input, DOT, FOLLOW_DOT_in_primaryExpression4302);
             if (state.failed) return retval;
 
             match(input, Token.DOWN, null);
             if (state.failed) return retval;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:796:5: (e= primaryExpression ( IDENT |
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:796:5: (e=
+            // primaryExpression ( IDENT |
             // THIS | SUPER | innerNewExpression | CLASS ) | primitiveType CLASS | VOID CLASS )
             int alt93 = 3;
             switch (input.LA(1)) {
@@ -7909,7 +8359,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt93) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:797:7: e= primaryExpression (
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:797:7: e=
+                // primaryExpression (
                 // IDENT | THIS | SUPER | innerNewExpression | CLASS )
                 {
                   pushFollow(FOLLOW_primaryExpression_in_primaryExpression4318);
@@ -7921,7 +8372,8 @@ public class JavaTreeParser extends TreeParser {
 
                     retval.value = (e != null ? e.value : null);
                   }
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:801:7: ( IDENT | THIS | SUPER |
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:801:7: (
+                  // IDENT | THIS | SUPER |
                   // innerNewExpression | CLASS )
                   int alt92 = 5;
                   switch (input.LA(1)) {
@@ -7962,7 +8414,8 @@ public class JavaTreeParser extends TreeParser {
 
                   switch (alt92) {
                     case 1:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:802:9: IDENT
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:802:9:
+                      // IDENT
                       {
                         IDENT40 =
                             (CommonTree) match(input, IDENT, FOLLOW_IDENT_in_primaryExpression4353);
@@ -7983,7 +8436,8 @@ public class JavaTreeParser extends TreeParser {
                       }
                       break;
                     case 2:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:811:11: THIS
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:811:11:
+                      // THIS
                       {
                         match(input, THIS, FOLLOW_THIS_in_primaryExpression4383);
                         if (state.failed) return retval;
@@ -7994,14 +8448,16 @@ public class JavaTreeParser extends TreeParser {
                       }
                       break;
                     case 3:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:815:11: SUPER
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:815:11:
+                      // SUPER
                       {
                         match(input, SUPER, FOLLOW_SUPER_in_primaryExpression4413);
                         if (state.failed) return retval;
                       }
                       break;
                     case 4:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:816:11: innerNewExpression
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:816:11:
+                      // innerNewExpression
                       {
                         pushFollow(FOLLOW_innerNewExpression_in_primaryExpression4425);
                         innerNewExpression();
@@ -8016,7 +8472,8 @@ public class JavaTreeParser extends TreeParser {
                       }
                       break;
                     case 5:
-                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:820:11: CLASS
+                      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:820:11:
+                      // CLASS
                       {
                         match(input, CLASS, FOLLOW_CLASS_in_primaryExpression4485);
                         if (state.failed) return retval;
@@ -8026,7 +8483,8 @@ public class JavaTreeParser extends TreeParser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:822:9: primitiveType CLASS
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:822:9:
+                // primitiveType CLASS
                 {
                   pushFollow(FOLLOW_primitiveType_in_primaryExpression4503);
                   primitiveType();
@@ -8038,7 +8496,8 @@ public class JavaTreeParser extends TreeParser {
                 }
                 break;
               case 3:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:823:9: VOID CLASS
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:823:9: VOID
+                // CLASS
                 {
                   match(input, VOID, FOLLOW_VOID_in_primaryExpression4515);
                   if (state.failed) return retval;
@@ -8053,7 +8512,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:826:5: parenthesizedExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:826:5:
+          // parenthesizedExpression
           {
             pushFollow(FOLLOW_parenthesizedExpression_in_primaryExpression4534);
             parenthesizedExpression41 = parenthesizedExpression();
@@ -8091,7 +8551,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:846:3: ^( METHOD_CALL o=
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:846:3: ^(
+          // METHOD_CALL o=
           // primaryExpression ( genericTypeArgumentList )? arguments )
           {
             match(input, METHOD_CALL, FOLLOW_METHOD_CALL_in_primaryExpression4585);
@@ -8104,7 +8565,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return retval;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:846:37: ( genericTypeArgumentList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:846:37: (
+            // genericTypeArgumentList )?
             int alt94 = 2;
             int LA94_0 = input.LA(1);
 
@@ -8113,7 +8575,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt94) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeArgumentList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeArgumentList
                 {
                   pushFollow(FOLLOW_genericTypeArgumentList_in_primaryExpression4591);
                   genericTypeArgumentList();
@@ -8143,7 +8606,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 5:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:853:5: explicitConstructorCall
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:853:5:
+          // explicitConstructorCall
           {
             pushFollow(FOLLOW_explicitConstructorCall_in_primaryExpression4618);
             explicitConstructorCall();
@@ -8158,7 +8622,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 6:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:858:3: ^( ARRAY_ELEMENT_ACCESS arr=
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:858:3: ^(
+          // ARRAY_ELEMENT_ACCESS arr=
           // primaryExpression index= expression )
           {
             match(
@@ -8202,7 +8667,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 8:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:866:5: newExpression
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:866:5:
+          // newExpression
           {
             pushFollow(FOLLOW_newExpression_in_primaryExpression4701);
             newExpression();
@@ -8228,7 +8694,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 10:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:874:5: arrayTypeDeclarator
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:874:5:
+          // arrayTypeDeclarator
           {
             pushFollow(FOLLOW_arrayTypeDeclarator_in_primaryExpression4749);
             arrayTypeDeclarator();
@@ -8266,8 +8733,10 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "primaryExpression"
 
   // $ANTLR start "explicitConstructorCall"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:881:1: explicitConstructorCall : ( ^(
-  // THIS_CONSTRUCTOR_CALL ( genericTypeArgumentList )? arguments ) | ^( SUPER_CONSTRUCTOR_CALL ( primaryExpression )? (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:881:1:
+  // explicitConstructorCall : ( ^(
+  // THIS_CONSTRUCTOR_CALL ( genericTypeArgumentList )? arguments ) | ^( SUPER_CONSTRUCTOR_CALL (
+  // primaryExpression )? (
   // genericTypeArgumentList )? arguments ) );
   public final void explicitConstructorCall() throws RecognitionException {
     int explicitConstructorCall_StartIndex = input.index();
@@ -8275,8 +8744,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 65)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:882:3: ( ^( THIS_CONSTRUCTOR_CALL (
-      // genericTypeArgumentList )? arguments ) | ^( SUPER_CONSTRUCTOR_CALL ( primaryExpression )? ( genericTypeArgumentList )?
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:882:3: ( ^(
+      // THIS_CONSTRUCTOR_CALL (
+      // genericTypeArgumentList )? arguments ) | ^( SUPER_CONSTRUCTOR_CALL ( primaryExpression )? (
+      // genericTypeArgumentList )?
       // arguments ) )
       int alt99 = 2;
       int LA99_0 = input.LA(1);
@@ -8296,7 +8767,8 @@ public class JavaTreeParser extends TreeParser {
       }
       switch (alt99) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:883:3: ^( THIS_CONSTRUCTOR_CALL (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:883:3: ^(
+          // THIS_CONSTRUCTOR_CALL (
           // genericTypeArgumentList )? arguments )
           {
             match(
@@ -8307,7 +8779,8 @@ public class JavaTreeParser extends TreeParser {
 
             match(input, Token.DOWN, null);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:883:27: ( genericTypeArgumentList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:883:27: (
+            // genericTypeArgumentList )?
             int alt96 = 2;
             int LA96_0 = input.LA(1);
 
@@ -8316,7 +8789,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt96) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeArgumentList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeArgumentList
                 {
                   pushFollow(FOLLOW_genericTypeArgumentList_in_explicitConstructorCall4791);
                   genericTypeArgumentList();
@@ -8338,7 +8812,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:885:3: ^( SUPER_CONSTRUCTOR_CALL (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:885:3: ^(
+          // SUPER_CONSTRUCTOR_CALL (
           // primaryExpression )? ( genericTypeArgumentList )? arguments )
           {
             match(
@@ -8349,7 +8824,8 @@ public class JavaTreeParser extends TreeParser {
 
             match(input, Token.DOWN, null);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:885:28: ( primaryExpression )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:885:28: (
+            // primaryExpression )?
             int alt97 = 2;
             int LA97_0 = input.LA(1);
 
@@ -8371,7 +8847,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt97) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: primaryExpression
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // primaryExpression
                 {
                   pushFollow(FOLLOW_primaryExpression_in_explicitConstructorCall4806);
                   primaryExpression();
@@ -8382,7 +8859,8 @@ public class JavaTreeParser extends TreeParser {
                 break;
             }
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:885:47: ( genericTypeArgumentList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:885:47: (
+            // genericTypeArgumentList )?
             int alt98 = 2;
             int LA98_0 = input.LA(1);
 
@@ -8391,7 +8869,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt98) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeArgumentList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeArgumentList
                 {
                   pushFollow(FOLLOW_genericTypeArgumentList_in_explicitConstructorCall4809);
                   genericTypeArgumentList();
@@ -8426,7 +8905,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "explicitConstructorCall"
 
   // $ANTLR start "arrayTypeDeclarator"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:888:1: arrayTypeDeclarator : ^( ARRAY_DECLARATOR (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:888:1: arrayTypeDeclarator
+  // : ^( ARRAY_DECLARATOR (
   // arrayTypeDeclarator | qualifiedIdentifier | primitiveType ) ) ;
   public final void arrayTypeDeclarator() throws RecognitionException {
     int arrayTypeDeclarator_StartIndex = input.index();
@@ -8434,9 +8914,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 66)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:889:3: ( ^( ARRAY_DECLARATOR (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:889:3: ( ^(
+      // ARRAY_DECLARATOR (
       // arrayTypeDeclarator | qualifiedIdentifier | primitiveType ) ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:890:3: ^( ARRAY_DECLARATOR ( arrayTypeDeclarator
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:890:3: ^(
+      // ARRAY_DECLARATOR ( arrayTypeDeclarator
       // | qualifiedIdentifier | primitiveType ) )
       {
         match(input, ARRAY_DECLARATOR, FOLLOW_ARRAY_DECLARATOR_in_arrayTypeDeclarator4834);
@@ -8444,7 +8926,8 @@ public class JavaTreeParser extends TreeParser {
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:892:5: ( arrayTypeDeclarator |
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:892:5: (
+        // arrayTypeDeclarator |
         // qualifiedIdentifier | primitiveType )
         int alt100 = 3;
         switch (input.LA(1)) {
@@ -8483,7 +8966,8 @@ public class JavaTreeParser extends TreeParser {
 
         switch (alt100) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:893:7: arrayTypeDeclarator
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:893:7:
+            // arrayTypeDeclarator
             {
               pushFollow(FOLLOW_arrayTypeDeclarator_in_arrayTypeDeclarator4848);
               arrayTypeDeclarator();
@@ -8493,7 +8977,8 @@ public class JavaTreeParser extends TreeParser {
             }
             break;
           case 2:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:894:9: qualifiedIdentifier
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:894:9:
+            // qualifiedIdentifier
             {
               pushFollow(FOLLOW_qualifiedIdentifier_in_arrayTypeDeclarator4858);
               qualifiedIdentifier();
@@ -8503,7 +8988,8 @@ public class JavaTreeParser extends TreeParser {
             }
             break;
           case 3:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:895:9: primitiveType
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:895:9:
+            // primitiveType
             {
               pushFollow(FOLLOW_primitiveType_in_arrayTypeDeclarator4868);
               primitiveType();
@@ -8531,18 +9017,24 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "arrayTypeDeclarator"
 
   // $ANTLR start "newExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:900:1: newExpression : ( ^( STATIC_ARRAY_CREATOR (
-  // primitiveType newArrayConstruction | ( genericTypeArgumentList )? qualifiedTypeIdent newArrayConstruction ) ) | ^(
-  // CLASS_CONSTRUCTOR_CALL ( genericTypeArgumentList )? qualifiedTypeIdent arguments ( classTopLevelScope )? ) );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:900:1: newExpression : ( ^(
+  // STATIC_ARRAY_CREATOR (
+  // primitiveType newArrayConstruction | ( genericTypeArgumentList )? qualifiedTypeIdent
+  // newArrayConstruction ) ) | ^(
+  // CLASS_CONSTRUCTOR_CALL ( genericTypeArgumentList )? qualifiedTypeIdent arguments (
+  // classTopLevelScope )? ) );
   public final void newExpression() throws RecognitionException {
     int newExpression_StartIndex = input.index();
     try {
       if (state.backtracking > 0 && alreadyParsedRule(input, 67)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:901:3: ( ^( STATIC_ARRAY_CREATOR ( primitiveType
-      // newArrayConstruction | ( genericTypeArgumentList )? qualifiedTypeIdent newArrayConstruction ) ) | ^(
-      // CLASS_CONSTRUCTOR_CALL ( genericTypeArgumentList )? qualifiedTypeIdent arguments ( classTopLevelScope )? ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:901:3: ( ^(
+      // STATIC_ARRAY_CREATOR ( primitiveType
+      // newArrayConstruction | ( genericTypeArgumentList )? qualifiedTypeIdent newArrayConstruction
+      // ) ) | ^(
+      // CLASS_CONSTRUCTOR_CALL ( genericTypeArgumentList )? qualifiedTypeIdent arguments (
+      // classTopLevelScope )? ) )
       int alt105 = 2;
       int LA105_0 = input.LA(1);
 
@@ -8561,16 +9053,20 @@ public class JavaTreeParser extends TreeParser {
       }
       switch (alt105) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:902:3: ^( STATIC_ARRAY_CREATOR (
-          // primitiveType newArrayConstruction | ( genericTypeArgumentList )? qualifiedTypeIdent newArrayConstruction ) )
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:902:3: ^(
+          // STATIC_ARRAY_CREATOR (
+          // primitiveType newArrayConstruction | ( genericTypeArgumentList )? qualifiedTypeIdent
+          // newArrayConstruction ) )
           {
             match(input, STATIC_ARRAY_CREATOR, FOLLOW_STATIC_ARRAY_CREATOR_in_newExpression4900);
             if (state.failed) return;
 
             match(input, Token.DOWN, null);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:904:5: ( primitiveType
-            // newArrayConstruction | ( genericTypeArgumentList )? qualifiedTypeIdent newArrayConstruction )
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:904:5: (
+            // primitiveType
+            // newArrayConstruction | ( genericTypeArgumentList )? qualifiedTypeIdent
+            // newArrayConstruction )
             int alt102 = 2;
             int LA102_0 = input.LA(1);
 
@@ -8595,7 +9091,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt102) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:905:7: primitiveType
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:905:7:
+                // primitiveType
                 // newArrayConstruction
                 {
                   pushFollow(FOLLOW_primitiveType_in_newExpression4914);
@@ -8611,10 +9108,12 @@ public class JavaTreeParser extends TreeParser {
                 }
                 break;
               case 2:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:906:9: ( genericTypeArgumentList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:906:9: (
+                // genericTypeArgumentList
                 // )? qualifiedTypeIdent newArrayConstruction
                 {
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:906:9: ( genericTypeArgumentList )?
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:906:9: (
+                  // genericTypeArgumentList )?
                   int alt101 = 2;
                   int LA101_0 = input.LA(1);
 
@@ -8654,7 +9153,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:910:3: ^( CLASS_CONSTRUCTOR_CALL (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:910:3: ^(
+          // CLASS_CONSTRUCTOR_CALL (
           // genericTypeArgumentList )? qualifiedTypeIdent arguments ( classTopLevelScope )? )
           {
             match(
@@ -8663,7 +9163,8 @@ public class JavaTreeParser extends TreeParser {
 
             match(input, Token.DOWN, null);
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:910:28: ( genericTypeArgumentList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:910:28: (
+            // genericTypeArgumentList )?
             int alt103 = 2;
             int LA103_0 = input.LA(1);
 
@@ -8672,7 +9173,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt103) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeArgumentList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // genericTypeArgumentList
                 {
                   pushFollow(FOLLOW_genericTypeArgumentList_in_newExpression4953);
                   genericTypeArgumentList();
@@ -8693,7 +9195,8 @@ public class JavaTreeParser extends TreeParser {
 
             state._fsp--;
             if (state.failed) return;
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:910:82: ( classTopLevelScope )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:910:82: (
+            // classTopLevelScope )?
             int alt104 = 2;
             int LA104_0 = input.LA(1);
 
@@ -8702,7 +9205,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt104) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: classTopLevelScope
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // classTopLevelScope
                 {
                   pushFollow(FOLLOW_classTopLevelScope_in_newExpression4960);
                   classTopLevelScope();
@@ -8731,7 +9235,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "newExpression"
 
   // $ANTLR start "innerNewExpression"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:913:1: innerNewExpression : ^( CLASS_CONSTRUCTOR_CALL (
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:913:1: innerNewExpression :
+  // ^( CLASS_CONSTRUCTOR_CALL (
   // genericTypeArgumentList )? IDENT arguments ( classTopLevelScope )? ) ;
   public final void innerNewExpression() throws RecognitionException {
     int innerNewExpression_StartIndex = input.index();
@@ -8739,9 +9244,11 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 68)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:914:3: ( ^( CLASS_CONSTRUCTOR_CALL (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:914:3: ( ^(
+      // CLASS_CONSTRUCTOR_CALL (
       // genericTypeArgumentList )? IDENT arguments ( classTopLevelScope )? ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:915:3: ^( CLASS_CONSTRUCTOR_CALL (
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:915:3: ^(
+      // CLASS_CONSTRUCTOR_CALL (
       // genericTypeArgumentList )? IDENT arguments ( classTopLevelScope )? )
       {
         match(
@@ -8750,7 +9257,8 @@ public class JavaTreeParser extends TreeParser {
 
         match(input, Token.DOWN, null);
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:915:28: ( genericTypeArgumentList )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:915:28: (
+        // genericTypeArgumentList )?
         int alt106 = 2;
         int LA106_0 = input.LA(1);
 
@@ -8759,7 +9267,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt106) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: genericTypeArgumentList
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+            // genericTypeArgumentList
             {
               pushFollow(FOLLOW_genericTypeArgumentList_in_innerNewExpression4981);
               genericTypeArgumentList();
@@ -8777,7 +9286,8 @@ public class JavaTreeParser extends TreeParser {
 
         state._fsp--;
         if (state.failed) return;
-        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:915:69: ( classTopLevelScope )?
+        // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:915:69: (
+        // classTopLevelScope )?
         int alt107 = 2;
         int LA107_0 = input.LA(1);
 
@@ -8786,7 +9296,8 @@ public class JavaTreeParser extends TreeParser {
         }
         switch (alt107) {
           case 1:
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: classTopLevelScope
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+            // classTopLevelScope
             {
               pushFollow(FOLLOW_classTopLevelScope_in_innerNewExpression4988);
               classTopLevelScope();
@@ -8814,7 +9325,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "innerNewExpression"
 
   // $ANTLR start "newArrayConstruction"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:918:1: newArrayConstruction : ( arrayDeclaratorList
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:918:1: newArrayConstruction
+  // : ( arrayDeclaratorList
   // arrayInitializer | ( expression )+ ( arrayDeclaratorList )? );
   public final void newArrayConstruction() throws RecognitionException {
     int newArrayConstruction_StartIndex = input.index();
@@ -8822,7 +9334,8 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 69)) {
         return;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:919:3: ( arrayDeclaratorList arrayInitializer |
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:919:3: (
+      // arrayDeclaratorList arrayInitializer |
       // ( expression )+ ( arrayDeclaratorList )? )
       int alt110 = 2;
       int LA110_0 = input.LA(1);
@@ -8842,7 +9355,8 @@ public class JavaTreeParser extends TreeParser {
       }
       switch (alt110) {
         case 1:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:920:3: arrayDeclaratorList arrayInitializer
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:920:3:
+          // arrayDeclaratorList arrayInitializer
           {
             pushFollow(FOLLOW_arrayDeclaratorList_in_newArrayConstruction5005);
             arrayDeclaratorList();
@@ -8857,10 +9371,12 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:921:5: ( expression )+ (
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:921:5: ( expression
+          // )+ (
           // arrayDeclaratorList )?
           {
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:921:5: ( expression )+
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:921:5: (
+            // expression )+
             int cnt108 = 0;
             loop108:
             do {
@@ -8873,7 +9389,8 @@ public class JavaTreeParser extends TreeParser {
 
               switch (alt108) {
                 case 1:
-                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: expression
+                  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                  // expression
                   {
                     pushFollow(FOLLOW_expression_in_newArrayConstruction5013);
                     expression();
@@ -8895,7 +9412,8 @@ public class JavaTreeParser extends TreeParser {
               cnt108++;
             } while (true);
 
-            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:921:17: ( arrayDeclaratorList )?
+            // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:921:17: (
+            // arrayDeclaratorList )?
             int alt109 = 2;
             int LA109_0 = input.LA(1);
 
@@ -8904,7 +9422,8 @@ public class JavaTreeParser extends TreeParser {
             }
             switch (alt109) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0: arrayDeclaratorList
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:0:0:
+                // arrayDeclaratorList
                 {
                   pushFollow(FOLLOW_arrayDeclaratorList_in_newArrayConstruction5016);
                   arrayDeclaratorList();
@@ -8930,7 +9449,8 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "newArrayConstruction"
 
   // $ANTLR start "arguments"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:924:1: arguments returns [List < com.sun.jdi.Value >
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:924:1: arguments returns
+  // [List < com.sun.jdi.Value >
   // args] : ^( ARGUMENT_LIST (e= expression )* ) ;
   public final List<com.sun.jdi.Value> arguments() throws RecognitionException {
     List<com.sun.jdi.Value> args = null;
@@ -8941,8 +9461,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 70)) {
         return args;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:925:3: ( ^( ARGUMENT_LIST (e= expression )* ) )
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:926:17: ^( ARGUMENT_LIST (e= expression )* )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:925:3: ( ^(
+      // ARGUMENT_LIST (e= expression )* ) )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:926:17: ^(
+      // ARGUMENT_LIST (e= expression )* )
       {
         if (state.backtracking == 0) {
 
@@ -8954,7 +9476,8 @@ public class JavaTreeParser extends TreeParser {
         if (input.LA(1) == Token.DOWN) {
           match(input, Token.DOWN, null);
           if (state.failed) return args;
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:931:5: (e= expression )*
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:931:5: (e=
+          // expression )*
           loop111:
           do {
             int alt111 = 2;
@@ -8966,7 +9489,8 @@ public class JavaTreeParser extends TreeParser {
 
             switch (alt111) {
               case 1:
-                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:932:7: e= expression
+                // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:932:7: e=
+                // expression
                 {
                   pushFollow(FOLLOW_expression_in_arguments5076);
                   e = expression();
@@ -9003,8 +9527,10 @@ public class JavaTreeParser extends TreeParser {
   // $ANTLR end "arguments"
 
   // $ANTLR start "literal"
-  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:940:1: literal returns [ExpressionValue value] : (
-  // HEX_LITERAL | OCTAL_LITERAL | DECIMAL_LITERAL | FLOATING_POINT_LITERAL | CHARACTER_LITERAL | STRING_LITERAL | TRUE | FALSE | NULL );
+  // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:940:1: literal returns
+  // [ExpressionValue value] : (
+  // HEX_LITERAL | OCTAL_LITERAL | DECIMAL_LITERAL | FLOATING_POINT_LITERAL | CHARACTER_LITERAL |
+  // STRING_LITERAL | TRUE | FALSE | NULL );
   public final ExpressionValue literal() throws RecognitionException {
     ExpressionValue value = null;
     int literal_StartIndex = input.index();
@@ -9021,8 +9547,10 @@ public class JavaTreeParser extends TreeParser {
       if (state.backtracking > 0 && alreadyParsedRule(input, 71)) {
         return value;
       }
-      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:941:3: ( HEX_LITERAL | OCTAL_LITERAL |
-      // DECIMAL_LITERAL | FLOATING_POINT_LITERAL | CHARACTER_LITERAL | STRING_LITERAL | TRUE | FALSE | NULL )
+      // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:941:3: ( HEX_LITERAL |
+      // OCTAL_LITERAL |
+      // DECIMAL_LITERAL | FLOATING_POINT_LITERAL | CHARACTER_LITERAL | STRING_LITERAL | TRUE |
+      // FALSE | NULL )
       int alt112 = 9;
       switch (input.LA(1)) {
         case HEX_LITERAL:
@@ -9094,7 +9622,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 2:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:946:5: OCTAL_LITERAL
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:946:5:
+          // OCTAL_LITERAL
           {
             OCTAL_LITERAL46 =
                 (CommonTree) match(input, OCTAL_LITERAL, FOLLOW_OCTAL_LITERAL_in_literal5149);
@@ -9106,7 +9635,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 3:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:950:5: DECIMAL_LITERAL
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:950:5:
+          // DECIMAL_LITERAL
           {
             DECIMAL_LITERAL47 =
                 (CommonTree) match(input, DECIMAL_LITERAL, FOLLOW_DECIMAL_LITERAL_in_literal5173);
@@ -9119,7 +9649,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 4:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:954:5: FLOATING_POINT_LITERAL
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:954:5:
+          // FLOATING_POINT_LITERAL
           {
             FLOATING_POINT_LITERAL48 =
                 (CommonTree)
@@ -9139,7 +9670,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 5:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:958:5: CHARACTER_LITERAL
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:958:5:
+          // CHARACTER_LITERAL
           {
             CHARACTER_LITERAL49 =
                 (CommonTree)
@@ -9154,7 +9686,8 @@ public class JavaTreeParser extends TreeParser {
           }
           break;
         case 6:
-          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:962:5: STRING_LITERAL
+          // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:962:5:
+          // STRING_LITERAL
           {
             STRING_LITERAL50 =
                 (CommonTree) match(input, STRING_LITERAL, FOLLOW_STRING_LITERAL_in_literal5245);
@@ -9214,7 +9747,8 @@ public class JavaTreeParser extends TreeParser {
 
   // $ANTLR start synpred125_JavaTreeParser
   public final void synpred125_JavaTreeParser_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:29: ( switchCaseLabel )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:29: ( switchCaseLabel
+    // )
     // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:509:29: switchCaseLabel
     {
       pushFollow(FOLLOW_switchCaseLabel_in_synpred125_JavaTreeParser1879);
@@ -9228,7 +9762,8 @@ public class JavaTreeParser extends TreeParser {
 
   // $ANTLR start synpred132_JavaTreeParser
   public final void synpred132_JavaTreeParser_fragment() throws RecognitionException {
-    // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:528:9: ( ( expression )* )
+    // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:528:9: ( ( expression )*
+    // )
     // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:528:9: ( expression )*
     {
       // org/eclipse/che/ide/ext/java/jdi/server/expression/JavaTreeParser.g:528:9: ( expression )*

--- a/swagger/che-swagger-module/src/main/java/org/eclipse/che/swagger/deploy/DocsModule.java
+++ b/swagger/che-swagger-module/src/main/java/org/eclipse/che/swagger/deploy/DocsModule.java
@@ -23,7 +23,8 @@ public class DocsModule extends AbstractModule {
 
     bind(org.eclipse.che.swagger.rest.SwaggerSpecificationService.class);
     bind(org.eclipse.che.swagger.rest.SwaggerSerializers.class).asEagerSingleton();
-    //trim is a fake to make this module dependent to commons lang3 and have correct version. this is need for dependency convergence.
+    // trim is a fake to make this module dependent to commons lang3 and have correct version. this
+    // is need for dependency convergence.
     final Multibinder<Class> ignoredCodenvyJsonClasses =
         Multibinder.newSetBinder(
             binder(), Class.class, Names.named(StringUtils.trim("che.json.ignored_classes")));


### PR DESCRIPTION
### What does this PR do?
Using formatter 2.0, we're now using v1.4 rules
https://github.com/google/google-java-format/releases/tag/google-java-format-1.4

It includes 
- 1.4 formatting level of google-format https://github.com/google/google-java-format/releases/tag/google-java-format-1.4
- display of invalid files (I've provided a pull request coveo/fmt-maven-plugin#17)
- add threadSafe flag (Provided as well as part of pull request) so there is no warning when you run the build with parallel flags.

### What issues does this PR fix or reference?
https://github.com/eclipse/che-parent/pull/33


#### Release Notes
Using new formatter rules (v1.4)
https://github.com/google/google-java-format

Plugins may require to be updated to be aligned with 1.4 rules
https://github.com/google/google-java-format/#using-the-formatter

#### Docs PR
N/A
