### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/che-terminal-client/.gitignore
+++ b/che-terminal-client/.gitignore
@@ -4,3 +4,4 @@ build/
 target/
 .idea/
 *.iml
+package-lock.json


### PR DESCRIPTION
### What does this PR do?
Apply package-lock.json to .gitignore . 

Signed-off-by: Aleksandr Andriienko <oandriie@redhat.com>

