### PR TITLE
Fix issue with Class path contains multiple SLF4J bindings. 

### DIFF
--- a/che-tomcat8-slf4j-logback/pom.xml
+++ b/che-tomcat8-slf4j-logback/pom.xml
@@ -36,24 +36,8 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.logstash.logback</groupId>
-            <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
@@ -99,14 +83,12 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.apache.tomcat:tomcat-juli</include>
-
                                     <include>org.slf4j:jcl-over-slf4j</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>ch.qos.logback:logback-classic</include>
                                     <include>ch.qos.logback:logback-core</include>
                                 </includes>
                             </artifactSet>
-
                             <filters>
                                 <filter>
                                     <artifact>org.apache.tomcat:tomcat-juli</artifact>

--- a/che-tomcat8-slf4j-logback/src/assembly/assembly.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/assembly.xml
@@ -28,14 +28,8 @@
             <outputDirectory>lib</outputDirectory>
             <includes>
                 <include>ch.qos.logback:logback-access</include>
-                <include>ch.qos.logback:logback-classic</include>
                 <include>ch.qos.logback:logback-core</include>
-                <include>com.fasterxml.jackson.core:jackson-annotations</include>
-                <include>com.fasterxml.jackson.core:jackson-core</include>
-                <include>com.fasterxml.jackson.core:jackson-databind</include>
-                <include>net.logstash.logback:logstash-logback-encoder</include>
                 <include>org.apache.tomcat:tomcat-catalina-jmx-remote</include>
-                <include>org.slf4j:slf4j-api</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
### What does this PR do?
Fix issue with Class path contains multiple SLF4J bindings. 
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/user/eclipse-che/tomcat/lib/logback-classic-1.2.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/user/eclipse-che/tomcat/webapps/api/WEB-INF/lib/logback-classic-1.2.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
```

logstash-logback-encoder dependency moved to individuals war files.
Linked to https://github.com/eclipse/che/pull/7444

