### PR TITLE
Add Keycloak Authorization to Swagger (Che 5)

### DIFF
--- a/swagger/che-swagger-war/src/main/webapp/index.html
+++ b/swagger/che-swagger-war/src/main/webapp/index.html
@@ -66,8 +66,9 @@
             hljs.highlightBlock(e)
           });
 
-          addApiKeyAuthorization();
+          addMachineTokenAuthorization();
           addCsrfAuthorization();
+          addKeycloakAuthorization();
         },
         onFailure: function(data) {
           log("Unable to Load SwaggerUI");
@@ -101,9 +102,24 @@
             }
           }
         });
-      };
+      }
 
-      $('#input_apiKey').change(addApiKeyAuthorization);
+      function addKeycloakAuthorization() {
+        $.when(initializeKeycloak()).then(function(keycloak) {
+          window.swaggerUi.api.clientAuthorizations.add("keycloak", new SwaggerClient.KeycloakAuthorization(keycloak));
+        });
+      }
+
+      function addMachineTokenAuthorization(){
+        var key = encodeURIComponent($('#input_apiKey')[0].value);
+        if(key && key.trim() != "") {
+          var machineTokenAuth = new SwaggerClient.ApiKeyAuthorization("token", key, "query");
+          window.swaggerUi.api.clientAuthorizations.add("machine_token", machineTokenAuth);
+          log("added machine token " + key);
+        }
+      }
+
+      $('#input_apiKey').change(addMachineTokenAuthorization);
 
       // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
       /*
@@ -118,7 +134,53 @@
           console.log.apply(console, arguments);
         }
       }
-  });
+
+      function initializeKeycloak() {
+        var deferred = $.Deferred();
+        if (this.keycloak) {
+          return deferred.resolve(keycloak);
+        } else {
+          $.when(getKeycloakConfiguration()).done(function(data) {
+            const script = document.createElement('script');
+            script.async = true;
+            script.src = keycloakSettings.url + "/js/keycloak.js";
+            script.onload = function () {
+              this.keycloak = Keycloak(keycloakSettings);
+              this.keycloak.init({
+                onLoad: 'login-required', checkLoginIframe: false
+              }).success(function (authenticated) {
+                deferred.resolve(this.keycloak);
+              }.bind(this)).error(function () {
+                console.log("Failed to load Keycloak script");
+                deferred.reject();
+              });
+            }.bind(this);
+            document.head.appendChild(script);
+          }.bind(this));
+          return deferred.promise();
+        }
+      }
+      
+      function getKeycloakConfiguration() {
+        var deferred = $.Deferred();
+        $.ajax({
+          url : "/api/keycloak/settings",
+          dataType: "json",
+          success: function(data) {
+            keycloakSettings = {
+              url: data['che.keycloak.auth_server_url'],
+              realm: data['che.keycloak.realm'],
+              clientId: data['che.keycloak.client_id']
+            };
+            deferred.resolve(keycloakSettings);
+          },
+          error: function () {
+            deferred.reject();
+          }
+        });
+        return deferred.promise();
+      }
+    });
   </script>
 </head>
 
@@ -128,7 +190,7 @@
     <a id="logo" href="http://swagger.io"></a>
     <form id='api_selector'>
       <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-      <div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
+      <div class='input'><input placeholder="token" id="input_apiKey" name="apiKey" type="text"/></div>
       <div class='input'><a id="explore" href="#" data-sw-translate>Explore</a></div>
     </form>
   </div>

--- a/swagger/che-swagger-war/src/main/webapp/swagger-ui.js
+++ b/swagger/che-swagger-war/src/main/webapp/swagger-ui.js
@@ -955,6 +955,7 @@ module.exports = SwaggerClient;
 SwaggerClient.ApiKeyAuthorization = auth.ApiKeyAuthorization;
 SwaggerClient.PasswordAuthorization = auth.PasswordAuthorization;
 SwaggerClient.CookieAuthorization = auth.CookieAuthorization;
+SwaggerClient.KeycloakAuthorization = auth.KeycloakAuthorization;
 SwaggerClient.SwaggerApi = deprecationWrapper;
 SwaggerClient.SwaggerClient = deprecationWrapper;
 SwaggerClient.SchemaMarkup = require('./lib/schema-markup');
@@ -1104,6 +1105,24 @@ PasswordAuthorization.prototype.apply = function (obj) {
     obj.headers.Authorization = 'Basic ' + btoa(this.username + ':' + this.password);
   }
 
+  return true;
+};
+
+/**
+ * Keycloak Authorization uses Keycloak Javascript Adapter to retrieve and refresh token
+ */
+var KeycloakAuthorization = module.exports.KeycloakAuthorization = function (keycloak) {
+  this.keycloak = keycloak;
+};
+
+KeycloakAuthorization.prototype.apply = function (obj) {
+  if(typeof obj.headers.Authorization === 'undefined') {
+    this.keycloak.updateToken(5).success(function(refreshed) {
+      obj.headers.Authorization = 'Bearer ' + this.keycloak.token;
+    }.bind(this)).error(function() {
+      console.log("failed to refresh Keycloak token");
+    });
+  }
   return true;
 };
 


### PR DESCRIPTION
What does this PR do?

Use Keycloak Javascript Adapter to authorize all swagger requests for multi-user assemblies.
Rework unused "api_key" field to be suited for machine authentication token.

What issues does this PR fix or reference?

eclipse/che#6015
eclipse/che#5664

Please review Che's Contributing Guide for best practices.

Tests written?

No

Docs updated?

N / A