### PR TITLE
Backport logger related changes from che6

### DIFF
--- a/che-tomcat8-slf4j-logback/pom.xml
+++ b/che-tomcat8-slf4j-logback/pom.xml
@@ -36,24 +36,8 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.logstash.logback</groupId>
-            <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
@@ -99,14 +83,12 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.apache.tomcat:tomcat-juli</include>
-
                                     <include>org.slf4j:jcl-over-slf4j</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>ch.qos.logback:logback-classic</include>
                                     <include>ch.qos.logback:logback-core</include>
                                 </includes>
                             </artifactSet>
-
                             <filters>
                                 <filter>
                                     <artifact>org.apache.tomcat:tomcat-juli</artifact>

--- a/che-tomcat8-slf4j-logback/pom.xml
+++ b/che-tomcat8-slf4j-logback/pom.xml
@@ -84,6 +84,7 @@
                                 <includes>
                                     <include>org.apache.tomcat:tomcat-juli</include>
                                     <include>org.slf4j:jcl-over-slf4j</include>
+                                    <include>org.slf4j:jul-to-slf4j</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>ch.qos.logback:logback-classic</include>
                                     <include>ch.qos.logback:logback-core</include>

--- a/che-tomcat8-slf4j-logback/src/assembly/assembly.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/assembly.xml
@@ -28,14 +28,8 @@
             <outputDirectory>lib</outputDirectory>
             <includes>
                 <include>ch.qos.logback:logback-access</include>
-                <include>ch.qos.logback:logback-classic</include>
                 <include>ch.qos.logback:logback-core</include>
-                <include>com.fasterxml.jackson.core:jackson-annotations</include>
-                <include>com.fasterxml.jackson.core:jackson-core</include>
-                <include>com.fasterxml.jackson.core:jackson-databind</include>
-                <include>net.logstash.logback:logstash-logback-encoder</include>
                 <include>org.apache.tomcat:tomcat-catalina-jmx-remote</include>
-                <include>org.slf4j:slf4j-api</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
@@ -12,6 +12,9 @@
 
 -->
 <configuration>
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
 
     <property name="max.retention.days" value="60" />
 
@@ -38,7 +41,6 @@
 
 
     <include optional="true" file="${che.local.conf.dir}/logback/logback-additional-appenders.xml"/>
-
     <include optional="true" file="${catalina.home}/conf/logback-additional-appenders.xml"/>
 
     <logger name="org.apache.catalina.loader" level="OFF"/>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logging.properties
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logging.properties
@@ -1,0 +1,1 @@
+handlers = org.apache.juli.logging.org.slf4j.bridge.SLF4JBridgeHandler

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-logger.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-logger.xml
@@ -12,6 +12,9 @@
 
 -->
 <configuration>
+    <contextListener class="org.apache.juli.logging.ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
 
     <property name="max.retention.days" value="60" />
 


### PR DESCRIPTION
### What does this PR do?
Backport logger related changes from che6
1. Fix issue with Class path contains multiple SLF4J bindings. https://github.com/eclipse/che-lib/pull/61
2. Enable jul->slf4j redirection https://github.com/eclipse/che-lib/pull/59

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/7564
### Previous behavior
(Remove this section if not relevant)

