### PR TITLE
[WIP] CHE-7008: Prepare xterm.js to use in the console output widget

### DIFF
--- a/che-terminal-client/gulpfile.js
+++ b/che-terminal-client/gulpfile.js
@@ -11,7 +11,14 @@ var uglify = require('gulp-uglify');
 
 
 var buildDir = process.env.BUILD_DIR || 'build';
-
+var browserifyOptions = {
+  basedir: buildDir,
+  debug: true,
+  entries: ['../lib/xterm.js', '../lib/addons/fit/fit.js'],
+  standalone: 'Terminal',
+  cache: {},
+  packageCache: {}
+};
 
 /**
  * Compile TypeScript sources to JavaScript files and create a source map file for each TypeScript
@@ -20,6 +27,7 @@ var buildDir = process.env.BUILD_DIR || 'build';
 gulp.task('tsc', function () {
   // Remove the lib/ directory to prevent confusion if files were deleted in src/
   fs.emptyDirSync('lib');
+  fs.emptyDirSync('build');
 
   // Build all TypeScript files (including tests) to lib/, based on the configuration defined in
   // `tsconfig.json`.
@@ -41,14 +49,22 @@ gulp.task('browserify', ['tsc'], function() {
   // Ensure that the build directory exists
   fs.ensureDirSync(buildDir);
 
-  var browserifyOptions = {
-    basedir: buildDir,
-    debug: true,
-    entries: ['../lib/xterm.js', '../lib/addons/fit/fit.js'],
-    standalone: 'Terminal',
-    cache: {},
-    packageCache: {}
-  };
+  return bundleStream = browserify(browserifyOptions)
+    .bundle()
+    .pipe(source('xterm.js'))
+    .pipe(buffer())
+    .pipe(uglify())
+    .pipe(gulp.dest(buildDir));
+});
+
+/**
+ * Bundle JavaScript files produced by the `tsc` task, into a single file named `xterm.js` with
+ * Browserify.
+ */
+gulp.task('browserify-with-source-map', ['tsc'], function() {
+  // Ensure that the build directory exists
+  fs.ensureDirSync(buildDir);
+
   return bundleStream = browserify(browserifyOptions)
     .bundle()
     .pipe(source('xterm.js'))
@@ -64,12 +80,14 @@ gulp.task('browserify', ['tsc'], function() {
  * (Without this task the source maps produced for the JavaScript bundle points into the
  * compiled JavaScript files in lib/).
  */
-gulp.task('sorcery', ['browserify'], function () {
+gulp.task('sorcery', ['browserify-with-source-map'], function () {
   var chain = sorcery.loadSync(`${buildDir}/xterm.js`);
   chain.apply();
   chain.writeSync();
 });
 
-gulp.task('build', ['sorcery']);
+gulp.task('build', ['browserify']);
 
 gulp.task('default', ['build']);
+
+gulp.task('dev', ['sorcery']);

--- a/che-terminal-client/pom.xml
+++ b/che-terminal-client/pom.xml
@@ -101,7 +101,7 @@
                         </goals>
                         <configuration>
                             <target name="copy xterm.js">
-                                <copy todir="${project.build.outputDirectory}">
+                                <copy todir="${project.build.outputDirectory}/org/eclipse/che/lib/terminal/client">
                                     <fileset dir="${basedir}/build" />
                                 </copy>
                             </target>

--- a/che-terminal-client/src/InputHandler.ts
+++ b/che-terminal-client/src/InputHandler.ts
@@ -50,7 +50,7 @@ export class InputHandler implements IInputHandler {
 
       // goto next line if ch would overflow
       // TODO: needs a global min terminal width of 2
-      if (this._terminal.x + ch_width - 1 >= this._terminal.cols) {
+      if (this._terminal.x + ch_width - 1 >= this._terminal.cols && !this._terminal.readOnly) {
         // autowrap - DECAWM
         if (this._terminal.wraparoundMode) {
           this._terminal.x = 0;
@@ -91,6 +91,9 @@ export class InputHandler implements IInputHandler {
       if (ch_width === 2) {
         this._terminal.lines.get(row)[this._terminal.x] = [this._terminal.curAttr, '', 0];
         this._terminal.x++;
+      }
+      if (this._terminal.readOnly && this._terminal.maxLineWidth < this._terminal.x) {
+        this._terminal.maxLineWidth = this._terminal.x;
       }
     }
   }

--- a/che-terminal-client/src/Interfaces.ts
+++ b/che-terminal-client/src/Interfaces.ts
@@ -19,6 +19,7 @@ export interface IBrowser {
 
 export interface ITerminal {
   element: HTMLElement;
+  rowContainerWrapper: HTMLElement;
   rowContainer: HTMLElement;
   textarea: HTMLTextAreaElement;
   ybase: number;
@@ -26,6 +27,8 @@ export interface ITerminal {
   lines: ICircularList<string>;
   rows: number;
   cols: number;
+  maxLineWidth: number;
+  readOnly: boolean;
   browser: IBrowser;
   writeBuffer: string[];
   children: HTMLElement[];
@@ -50,6 +53,12 @@ export interface ITerminal {
 export interface ICharMeasure {
   width: number;
   height: number;
+  measure(): void;
+}
+
+export interface IScrollBarMeasure {
+  verticalWidth: number;
+  horizontalWidth: number;
   measure(): void;
 }
 

--- a/che-terminal-client/src/Linkifier.ts
+++ b/che-terminal-client/src/Linkifier.ts
@@ -186,7 +186,7 @@ export class Linkifier {
       const node = nodes[i];
       const searchIndex = node.textContent.indexOf(uri);
       if (searchIndex >= 0) {
-        const linkElement = this._createAnchorElement(uri, handler, isHttpLinkMatcher);
+        const linkElement = this._createAnchorElement(uri, node.textContent, handler, isHttpLinkMatcher);
         if (node.textContent.length === uri.length) {
           // Matches entire string
 
@@ -229,7 +229,7 @@ export class Linkifier {
    * @param {string} uri The uri of the link.
    * @return {HTMLAnchorElement} The link.
    */
-  private _createAnchorElement(uri: string, handler: LinkMatcherHandler, isHypertextLinkHandler: boolean): HTMLAnchorElement {
+  private _createAnchorElement(uri: string, content: string, handler: LinkMatcherHandler, isHypertextLinkHandler: boolean): HTMLAnchorElement {
     const element = this._document.createElement('a');
     element.textContent = uri;
     if (isHypertextLinkHandler) {
@@ -238,7 +238,7 @@ export class Linkifier {
       element.target = '_blank';
       element.addEventListener('click', (event: MouseEvent) => {
         if (handler) {
-          return handler(event, uri);
+          return handler(event, uri, content);
         }
       });
     } else {
@@ -247,7 +247,9 @@ export class Linkifier {
         if (element.classList.contains(INVALID_LINK_CLASS)) {
           return;
         }
-        return handler(event, uri);
+        if (handler) {
+          return handler(event, uri, content);
+        }
       });
     }
     return element;

--- a/che-terminal-client/src/Renderer.ts
+++ b/che-terminal-client/src/Renderer.ts
@@ -123,7 +123,7 @@ export class Renderer {
     if (end - start >= this._terminal.rows / 2) {
       parent = this._terminal.element.parentNode;
       if (parent) {
-        this._terminal.element.removeChild(this._terminal.rowContainer);
+        this._terminal.rowContainerWrapper.removeChild(this._terminal.rowContainer);
       }
     }
 
@@ -281,7 +281,7 @@ export class Renderer {
     }
 
     if (parent) {
-      this._terminal.element.appendChild(this._terminal.rowContainer);
+      this._terminal.rowContainerWrapper.appendChild(this._terminal.rowContainer);
     }
 
     this._terminal.emit('refresh', {element: this._terminal.element, start: start, end: end});

--- a/che-terminal-client/src/Types.ts
+++ b/che-terminal-client/src/Types.ts
@@ -10,5 +10,5 @@ export type LinkMatcher = {
   validationCallback?: LinkMatcherValidationCallback,
   priority?: number
 };
-export type LinkMatcherHandler = (event: MouseEvent, uri: string) => boolean | void;
+export type LinkMatcherHandler = (event: MouseEvent, uri: string, content: string) => boolean | void;
 export type LinkMatcherValidationCallback = (uri: string, callback: (isValid: boolean) => void) => void;

--- a/che-terminal-client/src/Viewport.ts
+++ b/che-terminal-client/src/Viewport.ts
@@ -61,7 +61,7 @@ export class Viewport {
         this.lastRecordedViewportHeight = this.terminal.rows;
         let newHeight = this.charMeasure.height * this.terminal.rows;
         if (this.terminal.readOnly) {
-          this.viewportElement.style.height = '100%';
+          this.viewportElement.style.height = newHeight + this.scrollBarMeasure.getHorizontalWidth() + 'px';
         } else {
           this.viewportElement.style.height = newHeight + 'px';
         }

--- a/che-terminal-client/src/addons/fit/fit.js
+++ b/che-terminal-client/src/addons/fit/fit.js
@@ -37,13 +37,12 @@
     }
     var parentElementStyle = window.getComputedStyle(term.element.parentElement),
         parentElementHeight = parseInt(parentElementStyle.getPropertyValue('height')),
-        parentElementWidth = Math.max(0, parseInt(parentElementStyle.getPropertyValue('width')) - 17),
+        parentElementWidth = Math.max(0, parseInt(parentElementStyle.getPropertyValue('width')) - (term.scrollBarMeasure.getVerticalWidth() || 17)),
         elementStyle = window.getComputedStyle(term.element),
         elementPaddingVer = parseInt(elementStyle.getPropertyValue('padding-top')) + parseInt(elementStyle.getPropertyValue('padding-bottom')),
         elementPaddingHor = parseInt(elementStyle.getPropertyValue('padding-right')) + parseInt(elementStyle.getPropertyValue('padding-left')),
         availableHeight = parentElementHeight - elementPaddingVer,
         availableWidth = parentElementWidth - elementPaddingHor,
-        container = term.rowContainer,
         subjectRow = term.rowContainer.firstElementChild,
         contentBuffer = subjectRow.innerHTML,
         characterHeight,
@@ -51,6 +50,10 @@
         characterWidth,
         cols,
         geometry;
+
+    if (term.readOnly) {
+      availableHeight -= term.scrollBarMeasure.getHorizontalWidth() || 17;
+    }
 
     subjectRow.style.display = 'inline';
     subjectRow.innerHTML = 'W'; // Common character for measuring width, although on monospace

--- a/che-terminal-client/src/main/java/org/eclipse/che/lib/terminal/client/TerminalResources.java
+++ b/che-terminal-client/src/main/java/org/eclipse/che/lib/terminal/client/TerminalResources.java
@@ -12,10 +12,14 @@ package org.eclipse.che.lib.terminal.client;
 
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.resources.client.TextResource;
 
 /** @author Alexander Andrienko */
 public interface TerminalResources extends ClientBundle {
   @CssResource.NotStrict
   @Source({"xterm.css"})
   CssResource getTerminalStyle();
+
+  @Source("xterm.js")
+  TextResource xtermScript();
 }

--- a/che-terminal-client/src/main/resources/org/eclipse/che/lib/terminal/client/xterm.css
+++ b/che-terminal-client/src/main/resources/org/eclipse/che/lib/terminal/client/xterm.css
@@ -49,7 +49,7 @@
     left: 0;
     top: 0;
     right: 0;
-    bottom: 0;
+    height: 100%;
 }
 
 .terminal {
@@ -59,6 +59,7 @@
     font-feature-settings: "liga" 0;
     font-size: 11px;
     position: relative;
+    height: 100%;
 }
 
 .terminal.focus,
@@ -178,6 +179,12 @@
     /* On OS X this is required in order for the scroll bar to appear fully opaque */
     background-color: outputBackgroundColor;
     overflow-y: scroll;
+    overflow-x: hidden;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
 }
 
 .terminal .xterm-wide-char {
@@ -198,17 +205,12 @@
 
     left: 0;
     right: 0;
-    bottom: 0;
     top: 0;
-
-    /*white-space: pre;*/
-    /*word-wrap: normal;*/
 }
 
 .terminal .xterm-rows > div {
     /* Lines containing spans and text nodes ocassionally wrap despite being the same width (#327) */
     white-space: nowrap;
-    float: left;
 }
 
 .terminal .xterm-scroll-area {

--- a/che-terminal-client/src/main/resources/org/eclipse/che/lib/terminal/client/xterm.css
+++ b/che-terminal-client/src/main/resources/org/eclipse/che/lib/terminal/client/xterm.css
@@ -39,10 +39,22 @@
 @eval blueIconColor org.eclipse.che.ide.api.theme.Style.theme.getBlueIconColor();
 @eval outputFontColor org.eclipse.che.ide.api.theme.Style.theme.getOutputFontColor();
 
+.rows-wrapper {
+    position: absolute;
+    overflow: hidden;
+    margin: 0px;
+    border-width: 0px;
+    padding: 0px;
+    background: transparent;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+}
+
 .terminal {
     background-color: outputBackgroundColor;
     color: outputFontColor;
-    border-color: transparent;
     font-family: "DejaVu Sans Mono", "Liberation Mono", monospace;
     font-feature-settings: "liga" 0;
     font-size: 11px;
@@ -174,16 +186,29 @@
 
 .terminal .xterm-rows {
     position: absolute;
-    left: 0;
-    top: 0;
+    border-width: 0px;
+    margin: 0px;
+    padding: 0px;
+    outline: none;
+    z-index: 1;
+
+    user-select: text;
     -moz-user-select: text;
     -webkit-user-select: text;
-    user-select: text;
+
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: 0;
+
+    /*white-space: pre;*/
+    /*word-wrap: normal;*/
 }
 
 .terminal .xterm-rows > div {
     /* Lines containing spans and text nodes ocassionally wrap despite being the same width (#327) */
     white-space: nowrap;
+    float: left;
 }
 
 .terminal .xterm-scroll-area {

--- a/che-terminal-client/src/utils/CharMeasure.ts
+++ b/che-terminal-client/src/utils/CharMeasure.ts
@@ -19,6 +19,14 @@ export class CharMeasure extends EventEmitter {
     super();
     this._document = document;
     this._parentElement = parentElement;
+
+    this._measureElement = this._document.createElement('span');
+    this._measureElement.style.position = 'absolute';
+    this._measureElement.style.top = '0';
+    this._measureElement.style.left = '-9999em';
+    this._measureElement.textContent = 'W';
+    this._measureElement.setAttribute('aria-hidden', 'true');
+    this._parentElement.appendChild(this._measureElement);
   }
 
   public get width(): number {
@@ -30,23 +38,6 @@ export class CharMeasure extends EventEmitter {
   }
 
   public measure(): void {
-    if (!this._measureElement) {
-      this._measureElement = this._document.createElement('span');
-      this._measureElement.style.position = 'absolute';
-      this._measureElement.style.top = '0';
-      this._measureElement.style.left = '-9999em';
-      this._measureElement.textContent = 'W';
-      this._measureElement.setAttribute('aria-hidden', 'true');
-      this._parentElement.appendChild(this._measureElement);
-      // Perform _doMeasure async if the element was just attached as sometimes
-      // getBoundingClientRect does not return accurate values without this.
-      setTimeout(() => this._doMeasure(), 0);
-    } else {
-      this._doMeasure();
-    }
-  }
-
-  private _doMeasure(): void {
     const geometry = this._measureElement.getBoundingClientRect();
     // The element is likely currently display:none, we should retain the
     // previous value.

--- a/che-terminal-client/src/utils/ScrollBarMeasure.ts
+++ b/che-terminal-client/src/utils/ScrollBarMeasure.ts
@@ -1,0 +1,74 @@
+/**
+ * @module xterm/utils/ScrollBarMeasure
+ * @license MIT
+ */
+
+import { EventEmitter } from '../EventEmitter.js';
+
+/**
+ * Utility class to measures the width of the vertical and horizontal scrollBars.
+ */
+export class ScrollBarMeasure extends EventEmitter {
+  private _document: Document;
+  private _parentElement: HTMLElement;
+  private _measureElement: HTMLElement;
+  private _childMeasureElement: HTMLElement;
+  private _verticalWidth: number;
+  private _horizontalWidth: number;
+
+  constructor(document: Document, parentElement: HTMLElement) {
+    super();
+    this._document = document;
+    this._parentElement = parentElement;
+
+    this._measureElement = document.createElement('div');
+    this._measureElement.style.visibility = 'hidden';
+    this._measureElement.style.position = 'absolute';
+    this._measureElement.style.top = '0';
+    this._measureElement.style.left = '-9999em';
+    this._measureElement.setAttribute('aria-hidden', 'true');
+    this._measureElement.style.width = '50px';
+    this._measureElement.style.height = '50px';
+    this._parentElement.appendChild(this._measureElement);
+  }
+
+  public getVerticalWidth(): number {
+    return this._verticalWidth || 17;
+  }
+
+  public getHorizontalWidth(): number {
+    return this._horizontalWidth || 17;
+  }
+
+  public measure(): void {
+    const widthWithoutScroll = this._measureElement.offsetWidth;
+    const heigthWithoutScroll = this._measureElement.offsetHeight;
+
+    if (this._childMeasureElement) {
+      this._measureElement.removeChild(this._childMeasureElement);
+      this._childMeasureElement = null;
+    }
+
+    // create child element
+    this._childMeasureElement = document.createElement('div');
+    this._childMeasureElement.style.width = '100%';
+    this._childMeasureElement.style.height = '100%';
+
+    this._measureElement.appendChild(this._childMeasureElement);
+
+    // activate scroll
+    this._measureElement.style.overflow = 'scroll';
+
+    const widthWithScroll = this._childMeasureElement.offsetWidth;
+    const heigthWithScroll = this._childMeasureElement.offsetHeight;
+
+    const verticalWidth = widthWithoutScroll - widthWithScroll;
+    const horizontalWidth = heigthWithoutScroll - heigthWithScroll;
+
+    if (this._verticalWidth !== verticalWidth || this._horizontalWidth !== horizontalWidth) {
+      this._verticalWidth = verticalWidth;
+      this._horizontalWidth = horizontalWidth;
+      this.emit('scrollbarsizechanged');
+    }
+  }
+}

--- a/che-terminal-client/src/xterm.js
+++ b/che-terminal-client/src/xterm.js
@@ -21,6 +21,7 @@ import { Parser } from './Parser';
 import { Renderer } from './Renderer';
 import { Linkifier } from './Linkifier';
 import { CharMeasure } from './utils/CharMeasure';
+import { ScrollBarMeasure } from './utils/ScrollBarMeasure';
 import * as Browser from './utils/Browser';
 import * as Keyboard from './utils/Keyboard';
 import { CHARSETS } from './Charsets';
@@ -126,6 +127,7 @@ function Terminal(options) {
   this.cols = options.cols || options.geometry[0];
   this.rows = options.rows || options.geometry[1];
   this.focusOnOpen = options.focusOnOpen;
+  this.readOnly = options.readOnly;
   this.geometry = [this.cols, this.rows];
 
   if (options.handler) {
@@ -152,6 +154,11 @@ function Terminal(options) {
    * The cursor's y position after ybase
    */
   this.y = 0;
+
+  /**
+   * vertical scroll width in readOnly mode.
+   */
+  this.maxLineWidth = 0;
 
   this.cursorState = 0;
   this.cursorHidden = false;
@@ -360,7 +367,8 @@ Terminal.defaults = {
   disableStdin: false,
   useFlowControl: false,
   tabStopWidth: 8,
-  focusOnOpen: true
+  focusOnOpen: true,
+  readOnly: false
   // programFeatures: false,
   // focusKeys: false,
 };
@@ -444,6 +452,7 @@ Terminal.prototype.setOption = function(key, value) {
       this.element.classList.toggle(`xterm-cursor-style-bar`, value === 'bar');
       break;
     case 'tabStopWidth': this.setupStops(); break;
+    case 'readOnly': this.readOnly = value;
   }
 };
 
@@ -502,12 +511,14 @@ Terminal.prototype.initGlobal = function() {
   on(this.element, 'copy', function (ev) {
     copyHandler.call(this, ev, term);
   });
-  on(this.textarea, 'paste', function (ev) {
-    pasteHandler.call(this, ev, term);
-  });
-  on(this.element, 'paste', function (ev) {
-    pasteHandler.call(this, ev, term);
-  });
+  if (!this.options.readOnly) {
+    on(this.textarea, 'paste', function (ev) {
+      pasteHandler.call(this, ev, term);
+    });
+    on(this.element, 'paste', function (ev) {
+      pasteHandler.call(this, ev, term);
+    });
+  }
 
   function rightClickHandlerWrapper (ev) {
     rightClickHandler.call(this, ev, term);
@@ -610,11 +621,13 @@ Terminal.prototype.open = function(parent) {
   this.element.classList.add('xterm-theme-' + this.theme);
   this.element.classList.toggle('xterm-cursor-blink', this.options.cursorBlink);
 
-  this.element.style.height
   this.element.setAttribute('tabindex', 0);
 
   this.viewportElement = document.createElement('div');
   this.viewportElement.classList.add('xterm-viewport');
+  if (this.readOnly) {
+    this.viewportElement.style.overflowX = "scroll";
+  }
   this.element.appendChild(this.viewportElement);
   this.viewportScrollArea = document.createElement('div');
   this.viewportScrollArea.classList.add('xterm-scroll-area');
@@ -624,7 +637,12 @@ Terminal.prototype.open = function(parent) {
   // produce the lines the lines.
   this.rowContainer = document.createElement('div');
   this.rowContainer.classList.add('xterm-rows');
-  this.element.appendChild(this.rowContainer);
+
+  this.rowContainerWrapper = document.createElement('div');
+  this.rowContainerWrapper.classList.add("rows-wrapper");
+  this.rowContainerWrapper.appendChild(this.rowContainer);
+  this.element.appendChild(this.rowContainerWrapper);
+
   this.children = [];
   this.linkifier = new Linkifier(document, this.children);
 
@@ -667,7 +685,14 @@ Terminal.prototype.open = function(parent) {
   });
   this.charMeasure.measure();
 
-  this.viewport = new Viewport(this, this.viewportElement, this.viewportScrollArea, this.charMeasure);
+  this.scrollBarMeasure = new ScrollBarMeasure(document, this.helperContainer);
+  this.scrollBarMeasure.on('scrollbarsizechanged', function () {
+    self.rowContainerWrapper.style.right = self.scrollBarMeasure.getVerticalWidth() + "px";
+    self.updateReadOnlyCSS();
+  });
+  this.scrollBarMeasure.measure();
+
+  this.viewport = new Viewport(this, this.viewportElement, this.viewportScrollArea, this.charMeasure, this.scrollBarMeasure);
   this.renderer = new Renderer(this);
 
   // Setup loop that draws to screen
@@ -726,6 +751,13 @@ Terminal.loadAddon = function(addon, callback) {
 Terminal.prototype.updateCharSizeCSS = function() {
   this.charSizeStyleElement.textContent = '.xterm-wide-char{width:' + (this.charMeasure.width * 2) + 'px;}';
 }
+
+Terminal.prototype.updateReadOnlyCSS = function () {
+  if (this.readOnly) {
+    this.viewportElement.style.overflowX = "scroll";
+    this.rowContainerWrapper.style.bottom = this.scrollBarMeasure.getHorizontalWidth() + "px";
+  }
+};
 
 /**
  * XTerm mouse events
@@ -1097,7 +1129,7 @@ Terminal.prototype.queueLinkification = function(start, end) {
  * Display the cursor element
  */
 Terminal.prototype.showCursor = function() {
-  if (!this.cursorState) {
+  if (!this.cursorState && !this.options.readOnly) {
     this.cursorState = 1;
     this.refresh(this.y, this.y);
   }
@@ -1191,6 +1223,14 @@ Terminal.prototype.scrollDisp = function(disp, suppressScrollEvent) {
   this.refresh(0, this.rows - 1);
 };
 
+Terminal.prototype.scrollHome = function () {
+  this.scrollDisp(-this.ydisp, false);
+};
+
+Terminal.prototype.scrollEnd = function () {
+  this.scrollDisp(this.lines.length - this.rows - this.ydisp, false);
+};
+
 /**
  * Scroll the display of the terminal by a number of pages.
  * @param {number} pageCount The number of pages to scroll (negative scrolls up).
@@ -1259,8 +1299,13 @@ Terminal.prototype.innerWrite = function() {
 
     this.parser.parse(data);
 
-    this.updateRange(this.y);
-    this.refresh(this.refreshStart, this.refreshEnd);
+    if (this.maxLineWidth > this.cols && this.readOnly) {
+      this.updateRange(this.y);
+      this.resize(this.maxLineWidth, this.rows);
+    } {
+      this.updateRange(this.y);
+      this.refresh(this.refreshStart, this.refreshEnd);
+    }
   }
   if (this.writeBuffer.length > 0) {
     // Allow renderer to catch up before processing the next batch
@@ -1892,7 +1937,12 @@ Terminal.prototype.resize = function(x, y) {
   this.scrollTop = 0;
   this.scrollBottom = y - 1;
 
-  this.charMeasure.measure();
+  if (this.charMeasure) {
+    this.charMeasure.measure();
+  }
+  if (this.scrollBarMeasure) {
+    this.scrollBarMeasure.measure();
+  }
 
   this.refresh(0, this.rows - 1);
 
@@ -2038,6 +2088,31 @@ Terminal.prototype.eraseLine = function(y) {
   this.eraseRight(0, y);
 };
 
+Terminal.prototype.maxLineLength = function() {
+  var max = 0;
+  this.lines._array.forEach(function(elem) {
+    if (max < elem.length) {
+      max = elem.length;
+    }
+  });
+  return max;
+};
+
+Terminal.prototype.getText = function() {
+  var content = "";
+  this.lines._array.forEach(
+    function(line) {
+      var lineContent = "";
+      for (var i = 0; i < line.length; i++) {
+        lineContent += line[i][1];
+      }
+      lineContent = lineContent.trim();
+      if (lineContent) {
+        content += lineContent + "\r\n";
+      }
+    });
+  return content;
+};
 
 /**
  * Return the data array of a blank line

--- a/che-terminal-client/src/xterm.js
+++ b/che-terminal-client/src/xterm.js
@@ -625,9 +625,6 @@ Terminal.prototype.open = function(parent) {
 
   this.viewportElement = document.createElement('div');
   this.viewportElement.classList.add('xterm-viewport');
-  if (this.readOnly) {
-    this.viewportElement.style.overflowX = "scroll";
-  }
   this.element.appendChild(this.viewportElement);
   this.viewportScrollArea = document.createElement('div');
   this.viewportScrollArea.classList.add('xterm-scroll-area');
@@ -755,6 +752,10 @@ Terminal.prototype.updateCharSizeCSS = function() {
 Terminal.prototype.updateReadOnlyCSS = function () {
   if (this.readOnly) {
     this.viewportElement.style.overflowX = "scroll";
+    this.viewportElement.style.bottom = 0 + "px";
+    this.viewportElement.style.top = "initial";
+
+    this.rowContainerWrapper.style.top = "initial";
     this.rowContainerWrapper.style.bottom = this.scrollBarMeasure.getHorizontalWidth() + "px";
   }
 };
@@ -1839,6 +1840,10 @@ Terminal.prototype.resize = function(x, y) {
     return;
   }
 
+  if (this.readOnly && this.charMeasure && this.charMeasure.height > 0) {
+    this.rowContainerWrapper.style.height = y * this.charMeasure.height + "px";
+  }
+
   var line
   , el
   , i
@@ -2236,6 +2241,13 @@ Terminal.prototype.reverseIndex = function() {
 Terminal.prototype.reset = function() {
   this.options.rows = this.rows;
   this.options.cols = this.cols;
+  if (this.readOnly) {
+    var cols = Math.floor(this.rowContainerWrapper.clientWidth / this.charMeasure.width);
+    if (this.maxLineWidth > cols) {
+      this.maxLineWidth = 0;
+      this.options.cols = cols;
+    }
+  }
   var customKeydownHandler = this.customKeydownHandler;
   var normal = this.normal;
   Terminal.call(this, this.options);


### PR DESCRIPTION
### What does this PR do?
Implement read only mode for terminal client and rendering vertical scrollbar in this mode(because xterm.js doesn't support yet text wrap feature).
Fix initialization charMeasure helper element.
Apply scrollBarMeasureHelper for evaluation scrollBar size.
Add ability to print text, when terminal is not opened yet. Can be useful accumulate received outputs when terminal widget or dom parent element of the terminal widget is not visible or is not attached yet,
or terminal widget is not visible.
Don't generate source map for terminal client widget for distribution.
Created separated gulp task for generation xterm.js source map for development purpose.
Inject terminal script with help GWT to simplify terminal injection flow and speed up development process.
Implemented methods for custom hotkeys.
Implemented getText method.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7008

### Tests written?
No

### Docs updated?
No

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
