### PR TITLE
CHE-8136: Fix cursor position while performing rename refactoring

### DIFF
--- a/che-orion-editor/src/main/patches/fix_linked_mode.diff
+++ b/che-orion-editor/src/main/patches/fix_linked_mode.diff
@@ -46,6 +46,22 @@ diff --git a/org/eclipse/che/orion/public/built-codeEdit/code_edit/built-codeEdi
  						model = this.linkedModeModel;
  					} else {
  						break;
+@@ -33555,12 +33555,15 @@
+
+                                // Cancel this modification and apply same modification to all positions in changing group
+                                this.ignoreVerify = true;
++                var delta = 0;
+                                for (i = sortedPositions.length - 1; i >= 0; i--) {
+                                        pos = sortedPositions[i];
+                                        if (pos.model === model && pos.group === changed.group) {
+                                                this.editor.setText(evnt.text, pos.oldOffset + deltaStart , pos.oldOffset + deltaEnd, false);
++                        delta = pos.oldOffset <= evnt.start ? delta + changeCount : delta;
+                                        }
+                                }
++                this.editor.setCaretOffset(evnt.end + delta);
+                                this.ignoreVerify = false;
+                                evnt.text = null;
+                                this._updateAnnotations(sortedPositions);
 @@ -33640,10 +33641,11 @@
  		 * Exits Linked Mode. Optionally places the caret at linkedMode escapePosition.
  		 * @param {Boolean} [escapePosition=false] if true, place the caret at the  escape position.


### PR DESCRIPTION
### What does this PR do?
 Fix cursor position while performing rename refactoring.

### What issues does this PR fix or reference?
eclipse/che#8136

### Previous behavior
Cursor goes to the top rename field when performing rename refactoring and renaming not the top field.

### New behavior
Cursor is in the position where typing was started.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
