### PR TITLE
CHE-9275: add switching plaintext vs JSON encoding of logs

### DIFF
--- a/che-tomcat8-slf4j-logback/pom.xml
+++ b/che-tomcat8-slf4j-logback/pom.xml
@@ -36,8 +36,24 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>
@@ -84,6 +100,10 @@
                                 <includes>
                                     <include>org.apache.tomcat:tomcat-juli</include>
                                     <include>org.slf4j:jcl-over-slf4j</include>
+                                    <include>net.logstash.logback:logstash-logback-encoder</include>
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
                                     <include>org.slf4j:jul-to-slf4j</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>ch.qos.logback:logback-classic</include>
@@ -99,7 +119,6 @@
                                         <include>META-INF/NOTICE</include>
                                     </includes>
                                 </filter>
-
                                 <!-- Exclude services from jcl-over-slf4j as not needed in this classloader-->
                                 <filter>
                                     <artifact>org.slf4j:jcl-over-slf4j</artifact>
@@ -107,7 +126,6 @@
                                         <exclude>META-INF/services/**</exclude>
                                     </excludes>
                                 </filter>
-
                                 <!-- Exclude services from logback-classic as not needed in this classloader -->
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic</artifact>
@@ -116,7 +134,6 @@
                                     </excludes>
                                 </filter>
                             </filters>
-
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.commons.logging</pattern>
@@ -130,20 +147,17 @@
                                     <pattern>ch.qos.logback</pattern>
                                     <shadedPattern>org.apache.juli.logging.ch.qos.logback</shadedPattern>
                                 </relocation>
-
                                 <!-- Located in org.apache.juli.logging.ch.qos.logback.classic.util.ContextInitializer -->
                                 <relocation>
                                     <pattern>logback.configurationFile</pattern>
                                     <shadedPattern>juli-logback.configurationFile</shadedPattern>
                                 </relocation>
-
                                 <!-- Located in org.apache.juli.logging.ch.qos.logback.classic.ClassicConstants -->
                                 <relocation>
                                     <pattern>logback.ContextSelector</pattern>
                                     <shadedPattern>juli-logback.ContextSelector</shadedPattern>
                                 </relocation>
                             </relocations>
-
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE</resource>

--- a/che-tomcat8-slf4j-logback/src/assembly/assembly.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/assembly.xml
@@ -93,7 +93,11 @@
             <includes>
                 <include>logback-access.xml</include>
                 <include>logback.xml</include>
+                <include>logback-json-appenders.xml</include>
+                <include>logback-plaintext-appenders.xml</include>
                 <include>tomcat-logger.xml</include>
+                <include>tomcat-json-appenders.xml</include>
+                <include>tomcat-plaintext-appenders.xml</include>
                 <include>server.xml</include>
                 <include>context.xml</include>
                 <include>logging.properties</include>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback-json-appenders.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback-json-appenders.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<included>
+    <appender name="stdout-json" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>identity_id</includeMdcKeyName>
+            <includeMdcKeyName>req_id</includeMdcKeyName>
+        </encoder>
+    </appender>
+
+    <root level="${che.logs.level:-INFO}">
+        <appender-ref ref="stdout-json"/>
+    </root>
+</included>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback-plaintext-appenders.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback-plaintext-appenders.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<included>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <append>true</append>
+        <prudent>true</prudent>
+        <encoder>
+            <charset>utf-8</charset>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${che.logs.dir}/archive/%d{yyyy/MM/dd}/catalina.log</fileNamePattern>
+            <maxHistory>${max.retention.days}</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <root level="${che.logs.level:-INFO}">
+        <appender-ref ref="stdout"/>
+        <appender-ref ref="file"/>
+    </root>
+</included>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
@@ -21,35 +21,12 @@
 
     <jmxConfigurator/>
 
-    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <append>true</append>
-        <prudent>true</prudent>
-        <encoder>
-            <charset>utf-8</charset>
-            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${che.logs.dir}/archive/%d{yyyy/MM/dd}/catalina.log</fileNamePattern>
-            <maxHistory>${max.retention.days}</maxHistory>
-        </rollingPolicy>
-    </appender>
-
-
     <include optional="true" file="${che.local.conf.dir}/logback/logback-additional-appenders.xml"/>
     <include optional="true" file="${catalina.home}/conf/logback-additional-appenders.xml"/>
+    <!--Include appenders file depending on the variable `che.logs.appenders_impl` -->
+    <include optional="false" file="${catalina.home}/conf/logback-${CHE_LOGS_APPENDERS_IMPL:-plaintext}-appenders.xml"/>
 
     <logger name="org.apache.catalina.loader" level="OFF"/>
     <logger name="org.apache.catalina.session.PersistentManagerBase" level="OFF"/>
     <logger name="org.apache.jasper.servlet.TldScanner" level="OFF"/>
-
-    <root level="${che.logs.level:-INFO}">
-        <appender-ref ref="stdout"/>
-        <appender-ref ref="file"/>
-    </root>
 </configuration>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/logback.xml
@@ -23,7 +23,7 @@
 
     <include optional="true" file="${che.local.conf.dir}/logback/logback-additional-appenders.xml"/>
     <include optional="true" file="${catalina.home}/conf/logback-additional-appenders.xml"/>
-    <!--Include appenders file depending on the variable `che.logs.appenders_impl` -->
+    <!--Include appenders file depending on the variable `CHE_LOGS_APPENDERS_IMPL` -->
     <include optional="false" file="${catalina.home}/conf/logback-${CHE_LOGS_APPENDERS_IMPL:-plaintext}-appenders.xml"/>
 
     <logger name="org.apache.catalina.loader" level="OFF"/>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-json-appenders.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-json-appenders.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<included>
+    <appender name="stdout-json" class="org.apache.juli.logging.ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>identity_id</includeMdcKeyName>
+            <includeMdcKeyName>req_id</includeMdcKeyName>
+        </encoder>
+    </appender>
+
+    <root level="${che.logs.level:-INFO}">
+        <appender-ref ref="stdout-json"/>
+    </root>
+</included>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-logger.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-logger.xml
@@ -20,33 +20,10 @@
 
     <jmxConfigurator/>
 
-    <appender name="stdout" class="org.apache.juli.logging.ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <!--Include appenders file depending on the variable `che.logs.appenders_impl` -->
+    <include optional="false" file="${catalina.home}/conf/tomcat-${CHE_LOGS_APPENDERS_IMPL:-plaintext}-appenders.xml"/>
 
-    <appender name="file" class="org.apache.juli.logging.ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${che.logs.dir}/logs/catalina.log</file>
-        <append>true</append>
-        <encoder>
-            <charset>utf-8</charset>
-            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
-        </encoder>
-        <rollingPolicy class="org.apache.juli.logging.ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${che.logs.dir}/archive/catalina-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
-            <maxHistory>${max.retention.days}</maxHistory>
-            <cleanHistoryOnStart>true</cleanHistoryOnStart>
-            <maxFileSize>20MB</maxFileSize>
-        </rollingPolicy>
-    </appender>
-
-   <logger name="org.apache.catalina.loader" level="OFF"/>
+    <logger name="org.apache.catalina.loader" level="OFF"/>
     <logger name="org.apache.catalina.session.PersistentManagerBase" level="OFF"/>
     <logger name="org.apache.jasper.servlet.TldScanner" level="OFF"/>
-
-    <root level="${che.logs.level:-INFO}">
-        <appender-ref ref="stdout"/>
-        <appender-ref ref="file"/>
-    </root>
 </configuration>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-logger.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-logger.xml
@@ -20,7 +20,7 @@
 
     <jmxConfigurator/>
 
-    <!--Include appenders file depending on the variable `che.logs.appenders_impl` -->
+    <!--Include appenders file depending on the variable `CHE_LOGS_APPENDERS_IMPL` -->
     <include optional="false" file="${catalina.home}/conf/tomcat-${CHE_LOGS_APPENDERS_IMPL:-plaintext}-appenders.xml"/>
 
     <logger name="org.apache.catalina.loader" level="OFF"/>

--- a/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-plaintext-appenders.xml
+++ b/che-tomcat8-slf4j-logback/src/assembly/conf/tomcat-plaintext-appenders.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<included>
+    <appender name="stdout" class="org.apache.juli.logging.ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="org.apache.juli.logging.ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${che.logs.dir}/logs/catalina.log</file>
+        <append>true</append>
+        <encoder>
+            <charset>utf-8</charset>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="org.apache.juli.logging.ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${che.logs.dir}/archive/catalina-%d{yyyyMMdd}-%i.log.zip</fileNamePattern>
+            <maxHistory>${max.retention.days}</maxHistory>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+            <maxFileSize>20MB</maxFileSize>
+        </rollingPolicy>
+    </appender>
+
+    <root level="${che.logs.level:-INFO}">
+        <appender-ref ref="stdout"/>
+        <appender-ref ref="file"/>
+    </root>
+</included>


### PR DESCRIPTION
### What does this PR do?
Add libraries needed for logstash logs encoder to tomcat-juli
to be able to encode logs of tomcat and exception of deployment of
wars.
Add optional JSON appenders configuration for tomcat-logger.xml and
logback.xml.
Add an ability to switch implementation of appenders from plaintext
to JSON by setting env var CHE_LOGS_APPENDERS_IMPL. Values
suppoorted by default are: plaintext, json. If another appenders
configuration is needed assembly can add it to tomcat/conf folder
with names: tomcat-<myimpl>-appenders.xml,
logback-<myimpl>-appenders.xml and declare env var
CHE_LOGS_APPENDERS_IMPL=myimpl.

### What issues does this PR fix or reference?
Fixes eclipse/che#9275

### Previous behavior
Earlier plaintext encoding was used for logback and to configure JSON encoder we had to add appender conf. JSON encoding of tomcat logs was not available. 

### New behavior
We can declare environment variable CHE_LOGS_APPENDERS_IMPL=json to switch to JSON encoding of logs of both logback of wars and tomcat logs.

### Tests written?
No

### Docs updated?
Docs PR https://github.com/eclipse/che-docs/pull/384
