### PR TITLE
Use artifact specification version as swagger api version

### DIFF
--- a/swagger/che-swagger-module/pom.xml
+++ b/swagger/che-swagger-module/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>

--- a/swagger/che-swagger-module/src/main/java/org/eclipse/che/swagger/deploy/BasicSwaggerConfigurationModule.java
+++ b/swagger/che-swagger-module/src/main/java/org/eclipse/che/swagger/deploy/BasicSwaggerConfigurationModule.java
@@ -47,7 +47,7 @@ public class BasicSwaggerConfigurationModule extends ServletModule {
           BasicSwaggerConfigurationModule.class.getProtectionDomain().getCodeSource().getLocation();
       try (JarFile jar = new JarFile(new File(url.toURI()))) {
         final Manifest manifest = requireNonNull(jar.getManifest(), "Manifest must not be null");
-        return manifest.getMainAttributes().getValue("Implementation-Version");
+        return manifest.getMainAttributes().getValue("Specification-Version");
       }
     } catch (Exception e) {
       LOG.warn("Unable to retrieve implementation version from manifest file", e);

--- a/swagger/che-swagger-module/src/main/java/org/eclipse/che/swagger/deploy/BasicSwaggerConfigurationModule.java
+++ b/swagger/che-swagger-module/src/main/java/org/eclipse/che/swagger/deploy/BasicSwaggerConfigurationModule.java
@@ -50,7 +50,7 @@ public class BasicSwaggerConfigurationModule extends ServletModule {
         return manifest.getMainAttributes().getValue("Specification-Version");
       }
     } catch (Exception e) {
-      LOG.warn("Unable to retrieve implementation version from manifest file", e);
+      LOG.error("Unable to retrieve implementation version from manifest file", e);
       return "unknown";
     }
   }

--- a/swagger/che-swagger-module/src/main/java/org/eclipse/che/swagger/deploy/BasicSwaggerConfigurationModule.java
+++ b/swagger/che-swagger-module/src/main/java/org/eclipse/che/swagger/deploy/BasicSwaggerConfigurationModule.java
@@ -10,8 +10,15 @@
  */
 package org.eclipse.che.swagger.deploy;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.servlet.ServletModule;
+import java.io.File;
+import java.net.URL;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import org.slf4j.LoggerFactory;
 
 /**
  * Module provide basic swagger configuration
@@ -19,6 +26,9 @@ import com.google.inject.servlet.ServletModule;
  * @author Sergii Kabashnyuk
  */
 public class BasicSwaggerConfigurationModule extends ServletModule {
+  private static final org.slf4j.Logger LOG =
+      LoggerFactory.getLogger(BasicSwaggerConfigurationModule.class);
+
   @Override
   protected void configureServlets() {
     bind(io.swagger.jaxrs.config.DefaultJaxrsConfig.class).asEagerSingleton();
@@ -26,8 +36,22 @@ public class BasicSwaggerConfigurationModule extends ServletModule {
         .with(
             io.swagger.jaxrs.config.DefaultJaxrsConfig.class,
             ImmutableMap.of(
-                "api.version", "1.0",
+                "api.version", getCheVersion(),
                 "swagger.api.title", "Eclipse Che",
                 "swagger.api.basepath", "/api"));
+  }
+
+  private String getCheVersion() {
+    try {
+      URL url =
+          BasicSwaggerConfigurationModule.class.getProtectionDomain().getCodeSource().getLocation();
+      try (JarFile jar = new JarFile(new File(url.toURI()))) {
+        final Manifest manifest = requireNonNull(jar.getManifest(), "Manifest must not be null");
+        return manifest.getMainAttributes().getValue("Implementation-Version");
+      }
+    } catch (Exception e) {
+      LOG.warn("Unable to retrieve implementation version from manifest file", e);
+      return "unknown";
+    }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Use Che version to display as Swagger's api version (it is retrieved for war manifest file).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10351

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
Yes/No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
