### PR TITLE
Added dummy class to force maven to generate sources and javadoc

### DIFF
--- a/che-tomcat8-slf4j-logback/src/main/java/App.java
+++ b/che-tomcat8-slf4j-logback/src/main/java/App.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which is available at http://www.eclipse.org/legal/epl-2.0.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+/** This is a dummy class to force maven to generate sources and javadoc artifacts */
+public class App {
+
+  public static void main(String[] args) {}
+}

--- a/org-eclipse-jdt-core-repack/src/main/java/App.java
+++ b/org-eclipse-jdt-core-repack/src/main/java/App.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which is available at http://www.eclipse.org/legal/epl-2.0.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+/** This is a dummy class to force maven to generate sources and javadoc artifacts */
+public class App {
+
+  public static void main(String[] args) {}
+}


### PR DESCRIPTION
Added dummy class to force maven to generate sources and javadoc artifacts.
Without that we can't publish che-lib on central