### PR TITLE
replace call to npm executable with...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ Thumbs.db
 *~
 
 /**/node_modules/
+node/

--- a/che-terminal-client/package.json
+++ b/che-terminal-client/package.json
@@ -27,7 +27,7 @@
     "src/**/*.ts"
   ],
   "devDependencies": {
-    "2": "^1.0.2",
+    "2": "1.0.2",
     "@types/node": "6.0.41",
     "browserify": "13.1.0",
     "fs-extra": "1.0.0",

--- a/che-terminal-client/package.json
+++ b/che-terminal-client/package.json
@@ -27,18 +27,19 @@
     "src/**/*.ts"
   ],
   "devDependencies": {
+    "2": "^1.0.2",
     "@types/node": "6.0.41",
-    "browserify": "13.1.0",
-    "fs-extra": "1.0.0",
-    "gulp": "3.9.1",
-    "gulp-sourcemaps": "2.4.0",
-    "gulp-typescript": "3.1.4",
-    "merge-stream": "1.0.1",
-    "sorcery": "0.10.0",
-    "gulp-uglify": "2.0.0",
-    "typescript": "2.1.5",
-    "vinyl-buffer": "1.0.0",
-    "vinyl-source-stream": "1.1.0"
+    "browserify": "^13.1.0",
+    "fs-extra": "^1.0.0",
+    "gulp": "^3.9.1",
+    "gulp-sourcemaps": "^2.4.0",
+    "gulp-typescript": "^3.1.4",
+    "gulp-uglify": "^2.0.0",
+    "merge-stream": "^1.0.1",
+    "sorcery": "^0.10.0",
+    "typescript": "^2.1.5",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {
     "build": "gulp build"

--- a/che-terminal-client/package.json
+++ b/che-terminal-client/package.json
@@ -29,17 +29,17 @@
   "devDependencies": {
     "2": "^1.0.2",
     "@types/node": "6.0.41",
-    "browserify": "^13.1.0",
-    "fs-extra": "^1.0.0",
-    "gulp": "^3.9.1",
-    "gulp-sourcemaps": "^2.4.0",
-    "gulp-typescript": "^3.1.4",
-    "gulp-uglify": "^2.0.0",
-    "merge-stream": "^1.0.1",
-    "sorcery": "^0.10.0",
-    "typescript": "^2.1.5",
-    "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "browserify": "13.1.0",
+    "fs-extra": "1.0.0",
+    "gulp": "3.9.1",
+    "gulp-sourcemaps": "2.4.0",
+    "gulp-typescript": "3.1.4",
+    "gulp-uglify": "2.0.0",
+    "merge-stream": "1.0.1",
+    "sorcery": "0.10.0",
+    "typescript": "2.1.5",
+    "vinyl-buffer": "1.0.0",
+    "vinyl-source-stream": "1.1.0"
   },
   "scripts": {
     "build": "gulp build"

--- a/che-terminal-client/pom.xml
+++ b/che-terminal-client/pom.xml
@@ -77,7 +77,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install browserify vinyl-buffer fs-extra gulp merge-stream sorcery vinyl-source-stream gulp-sourcemaps gulp-typescript gulp-uglify typescript --save-dev --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
+                            <arguments>install --save-dev --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
                             <npmRegistryURL>http://registry.npmjs.org/</npmRegistryURL>
                         </configuration>
                     </execution>

--- a/che-terminal-client/pom.xml
+++ b/che-terminal-client/pom.xml
@@ -57,42 +57,45 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!--clean-up build folders-->
-                        <id>clean-up</id>
-                        <phase>clean</phase>
+                        <id>install node and npm</id>
+                        <phase>generate-resources</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <tasks>
-                                <delete dir="${basedir}/node_modules" />
-                                <delete dir="${basedir}/build" />
-                            </tasks>
+                            <arguments>install --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
                         </configuration>
                     </execution>
                     <execution>
-                        <!--compilation sources-->
-                        <id>compilation</id>
+                        <id>npm install</id>
                         <phase>compile</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <target>
-                                Download NPM dependencies
-                                <exec dir="${basedir}" executable="npm" failonerror="true">
-                                    <arg value="install" />
-                                </exec>
-                                <exec dir="${basedir}" executable="npm" failonerror="true">
-                                    <arg value="run-script" />
-                                    <arg value="build" />
-                                </exec>
-                            </target>
+                            <arguments>install browserify vinyl-buffer fs-extra gulp merge-stream sorcery vinyl-source-stream gulp-sourcemaps gulp-typescript gulp-uglify typescript --save-dev --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
+                            <npmRegistryURL>http://registry.npmjs.org/</npmRegistryURL>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>npm run script build</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>run-script build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
                     <execution>
                         <!--copy compiled terminal script to output directory-->
                         <id>copy-xterm.js</id>

--- a/che-test-ls/pom.xml
+++ b/che-test-ls/pom.xml
@@ -26,21 +26,27 @@
         <finalName>test-ls</finalName>
         <plugins>
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
+                        <id>install node and npm</id>
+                        <phase>generate-resources</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <target>
-                                <!-- Download NPM dependencies -->
-                                <exec dir="${basedir}/src" executable="npm" failonerror="true">
-                                    <arg value="install" />
-                                </exec>
-                            </target>
+                            <arguments>install --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm install</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>npm</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>install --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/che-test-ls/pom.xml
+++ b/che-test-ls/pom.xml
@@ -35,9 +35,6 @@
                         <goals>
                             <goal>install-node-and-npm</goal>
                         </goals>
-                        <configuration>
-                            <arguments>install --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>npm install</id>
@@ -45,9 +42,6 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
-                        <configuration>
-                            <arguments>install --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -49,4 +49,29 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
+
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <!-- Use the latest released version:
+                    https://repo1.maven.org/maven2/com/github/eirslett/frontend-maven-plugin/ -->
+                    <version>1.6</version>
+                    <configuration>
+                        <nodeVersion>v5.6.0</nodeVersion>
+                        <!-- optional: with node >4.0.0 will use npm provided by node distribution -->
+                        <!-- <npmVersion>2.15.9</npmVersion> -->
+                        <!-- must use http for NCL builds -->
+                        <downloadRoot>http://nodejs.org/dist/</downloadRoot>
+                        <npmDownloadRoot>http://registry.npmjs.org/npm/-/</npmDownloadRoot>
+                        <npmRegistryURL>http://registry.npmjs.org/</npmRegistryURL>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
 </project>


### PR DESCRIPTION
replace call to npm executable with frontend-maven-plugin call to embedded npm. Took only 14s seconds longer for the two changed npm-based builds (3m01s vs. 2m47s)

Change-Id: I439aa1855f7048c25af32d87f5fcf1af5ea5a0b2
Signed-off-by: nickboldt <nboldt@redhat.com>