### PR TITLE
Use styled dialog instead of browser pop-up for goto line in compare widget

### DIFF
--- a/che-orion-editor/src/main/resources/org/eclipse/che/orion/public/built-codeEdit/code_edit/built-codeEdit-amd.js
+++ b/che-orion-editor/src/main/resources/org/eclipse/che/orion/public/built-codeEdit/code_edit/built-codeEdit-amd.js
@@ -30972,13 +30972,26 @@ define("orion/editor/actions", [ //$NON-NLS-0$
 			var editor = this.editor;
 			var model = editor.getModel();
 			var line = model.getLineAtOffset(editor.getCaretOffset());
-			line = prompt(messages.gotoLinePrompty, line + 1);
-			if (line) {
-				line = parseInt(line, 10);
-				editor.onGotoLine(line - 1, 0);
-			}
-			return true;
-		},
+
+            if (window["promptIdeCompareWidget"]) {
+                window["promptIdeCompareWidget"](messages.gotoLine, messages.gotoLinePrompty, line + 1,
+                    function(value) {
+                        if (!value) return;
+                        if (value) {
+                            value = parseInt(value, 10);
+                            editor.onGotoLine(value - 1, 0);
+                            return;
+                        }
+                    });
+            } else {
+                line = prompt(messages.gotoLinePrompty, line + 1);
+                if (line) {
+                    line = parseInt(line, 10);
+                    editor.onGotoLine(line - 1, 0);
+                }
+            }
+            return true;
+        },
 		moveLinesDown: function() {
 			var editor = this.editor;
 			var textView = editor.getTextView();


### PR DESCRIPTION

Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### What does this PR do?
Use styled dialog instead of browser pop-up for goto file in compare widget
### What issues does this PR fix or reference?
eclipse/che#2299

### Previous behavior
(Remove this section if not relevant)

### New behavior
(Explain the PR as it should appear in the release notes)

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
Yes/No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
